### PR TITLE
API-511-1_클럽 생성

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
@@ -1,0 +1,69 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.ApiResponseDto;
+import com.taiso.bike_api.dto.ClubJoinResponseDTO;
+import com.taiso.bike_api.security.JwtTokenProvider;
+import com.taiso.bike_api.service.ClubMemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/clubs")
+public class ClubMemberController {
+
+    private final ClubMemberService clubMemberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public ClubMemberController(ClubMemberService clubMemberService,
+                                JwtTokenProvider jwtTokenProvider) {
+        this.clubMemberService = clubMemberService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @PostMapping("/{clubId}/members")
+    public ResponseEntity<?> joinClub(@PathVariable("clubId") Long clubId,
+                                      HttpServletRequest request) {
+        // 1. JWT 토큰 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 존재하지 않습니다."));
+        }
+
+        // 2. JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+
+        // 3. 토큰에서 사용자 식별자(예: 이메일) 추출
+        String email = jwtTokenProvider.getUsernameFromJWT(token);
+
+        try {
+            // 4. 서비스 호출하여 클럽 가입 신청 처리
+            ClubJoinResponseDTO responseDto = clubMemberService.joinClub(clubId, email);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // 에러 메시지에 따라 상태 코드 설정
+            if (errorMsg.equals("클럽이 존재하지 않습니다.")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ApiResponseDto(errorMsg));
+            } else if (errorMsg.equals("이미 해당 클럽에 참가 신청을 했습니다.") ||
+                       errorMsg.equals("이미 해당 클럽에 참여했습니다.")) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(new ApiResponseDto(errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto(errorMsg));
+            }
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
@@ -3,6 +3,7 @@ package com.taiso.bike_api.controller;
 import com.taiso.bike_api.dto.ApiResponseDto;
 import com.taiso.bike_api.dto.ClubJoinResponseDTO;
 import com.taiso.bike_api.dto.ClubJoinAcceptResponseDTO;
+import com.taiso.bike_api.dto.ClubJoinRejectResponseDTO;
 import com.taiso.bike_api.security.JwtTokenProvider;
 import com.taiso.bike_api.service.ClubMemberService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -98,6 +100,50 @@ public class ClubMemberController {
         } catch (IllegalArgumentException e) {
             String errorMsg = e.getMessage();
             // 에러 메시지에 따라 상태 코드 지정
+            if (errorMsg.equals("해당 사용자의 참가 신청이 존재하지 않습니다.")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ApiResponseDto(errorMsg));
+            } else if (errorMsg.equals("넌 이미 클럽 가입이 승인되었단다.")) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto(errorMsg));
+            } else if (errorMsg.equals("관리자 권한이 필요합니다.")) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(new ApiResponseDto(errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto(errorMsg));
+            }
+        }
+    }
+
+
+    // 클럽 가입 거절
+    @DeleteMapping("/{clubId}/members/{userId}")
+    public ResponseEntity<?> rejectClubJoin(
+            @PathVariable("clubId") Long clubId,
+            @PathVariable("userId") Long userId,
+            HttpServletRequest request) {
+
+        // 1. JWT 토큰 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 없엉."));
+        }
+        // 2. JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+        // 3. 토큰에서 관리자(어드민) 식별(예: 이메일 추출)
+        String adminEmail = jwtTokenProvider.getUsernameFromJWT(token);
+
+        try {
+            // 4. 서비스 호출하여 클럽 가입 거절 처리
+            ClubJoinRejectResponseDTO responseDto = clubMemberService.rejectClubJoin(clubId, userId, adminEmail);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
             if (errorMsg.equals("해당 사용자의 참가 신청이 존재하지 않습니다.")) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(new ApiResponseDto(errorMsg));

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/ClubMemberController.java
@@ -2,6 +2,7 @@ package com.taiso.bike_api.controller;
 
 import com.taiso.bike_api.dto.ApiResponseDto;
 import com.taiso.bike_api.dto.ClubJoinResponseDTO;
+import com.taiso.bike_api.dto.ClubJoinAcceptResponseDTO;
 import com.taiso.bike_api.security.JwtTokenProvider;
 import com.taiso.bike_api.service.ClubMemberService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +29,7 @@ public class ClubMemberController {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    // 클럽 가입 신청
     @PostMapping("/{clubId}/members")
     public ResponseEntity<?> joinClub(@PathVariable("clubId") Long clubId,
                                       HttpServletRequest request) {
@@ -59,6 +62,50 @@ public class ClubMemberController {
             } else if (errorMsg.equals("이미 해당 클럽에 참가 신청을 했습니다.") ||
                        errorMsg.equals("이미 해당 클럽에 참여했습니다.")) {
                 return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(new ApiResponseDto(errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto(errorMsg));
+            }
+        }
+    }
+
+    // 클럽 가입 승인
+    @PatchMapping("/{clubId}/members/{userId}")
+    public ResponseEntity<?> acceptClubJoin(
+            @PathVariable("clubId") Long clubId,
+            @PathVariable("userId") Long userId,
+            HttpServletRequest request) {
+
+        // 1. JWT 토큰 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 없엉."));
+        }
+        // 2. JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+        // 3. 토큰에서 관리자(어드민) 사용자 식별(예: 이메일 추출)
+        String adminEmail = jwtTokenProvider.getUsernameFromJWT(token);
+
+        try {
+            // 4. 서비스 호출하여 클럽 가입 수락 처리
+            ClubJoinAcceptResponseDTO responseDto = clubMemberService.acceptClubJoin(clubId, userId, adminEmail);
+            return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // 에러 메시지에 따라 상태 코드 지정
+            if (errorMsg.equals("해당 사용자의 참가 신청이 존재하지 않습니다.")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ApiResponseDto(errorMsg));
+            } else if (errorMsg.equals("넌 이미 클럽 가입이 승인되었단다.")) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto(errorMsg));
+            } else if (errorMsg.equals("관리자 권한이 필요합니다.")) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
                         .body(new ApiResponseDto(errorMsg));
             } else {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/LightningController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/LightningController.java
@@ -1,11 +1,12 @@
 package com.taiso.bike_api.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-
 
 @RestController
 @Slf4j

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/LightningUserController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/LightningUserController.java
@@ -1,0 +1,63 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.ApiResponseDto;
+import com.taiso.bike_api.dto.LightningResponseDTO;
+import com.taiso.bike_api.security.JwtTokenProvider;
+import com.taiso.bike_api.service.LightningService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/me/lightings")
+public class LightningUserController {
+
+    private final LightningService lightningService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public LightningUserController(LightningService lightningService,
+                                   JwtTokenProvider jwtTokenProvider) {
+        this.lightningService = lightningService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getUserLightningEvents(@RequestParam("status") int status,
+                                                    HttpServletRequest request) {
+        // 1. JWT 토큰 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 존재하지 않습니다."));
+        }
+        // 2. JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+        // 3. 토큰에서 사용자 식별자(이메일) 추출
+        String email = jwtTokenProvider.getUsernameFromJWT(token);
+
+        // 4. 서비스 호출하여 사용자와 연관된 번개 이벤트 목록 조회
+        List<LightningResponseDTO> lightningEvents;
+        try {
+            lightningEvents = lightningService.getUserLightningEvents(email, status);
+            if (lightningEvents == null || lightningEvents.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(new ApiResponseDto("아무런 번개가 존재하지 않습니다."));
+            }
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponseDto(e.getMessage()));
+        }
+        // 5. 조회 결과 응답 (200 OK)
+        return ResponseEntity.status(HttpStatus.OK).body(lightningEvents);
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/UserDetailController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/UserDetailController.java
@@ -2,14 +2,20 @@ package com.taiso.bike_api.controller;
 
 import com.taiso.bike_api.dto.ApiResponseDto;
 import com.taiso.bike_api.dto.UserDetailRequestDTO;
+import com.taiso.bike_api.dto.UserDetailResponseDTO;
+import com.taiso.bike_api.dto.UserDetailUpdateDTO;
 import com.taiso.bike_api.security.JwtTokenProvider;
 import com.taiso.bike_api.service.UserDetailService;
 import com.taiso.bike_api.service.UserDetailMeTourokuService;
+import com.taiso.bike_api.service.UserDetailMeUpdateService;
+import com.taiso.bike_api.service.UserDetailMeShowService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,20 +25,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users/me")
 public class UserDetailController {
 
+    private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailService userDetailService;
     private final UserDetailMeTourokuService userDetailMeTourokuService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailMeShowService userDetailMeShowService;
+    private final UserDetailMeUpdateService userDetailMeUpdateService;
 
     @Autowired
-    public UserDetailController(UserDetailService userDetailService,
+    public UserDetailController(JwtTokenProvider jwtTokenProvider,
+                                UserDetailService userDetailService,
                                 UserDetailMeTourokuService userDetailMeTourokuService,
-                                JwtTokenProvider jwtTokenProvider
+                                UserDetailMeShowService userDetailMeShowService,
+                                UserDetailMeUpdateService userDetailMeUpdateService
                                 ) {
-        this.userDetailService = userDetailService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailService = userDetailService;
         this.userDetailMeTourokuService = userDetailMeTourokuService;
+        this.userDetailMeShowService = userDetailMeShowService;
+        this.userDetailMeUpdateService = userDetailMeUpdateService;
     }
 
+    // 내 디테일 정보 등록 (UserDetailMeTourokyService))
     @PostMapping("/details")
     public ResponseEntity<ApiResponseDto> registerUserDetails(
             @RequestBody @Valid UserDetailRequestDTO requestDto,
@@ -65,4 +78,73 @@ public class UserDetailController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponseDto("내 디테일 정보가 등록되었습니다."));
     }
+
+    // 내 정보 보기 (UserDetailMeShowService)
+    @GetMapping("/details")
+    public ResponseEntity<?> getUserDetails(HttpServletRequest request) {
+        // JWT 토큰 추출 (헤더에 "Authorization"에 담겨있다고 가정)
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 존재하지 않습니다."));
+        }
+
+        // JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+
+        // 토큰에서 사용자 식별자(이메일) 추출
+        String email = jwtTokenProvider.getUsernameFromJWT(token);
+
+        // 서비스 호출: 이메일을 기준으로 사용자 디테일 정보 조회
+        UserDetailResponseDTO responseDto;
+        try {
+            responseDto = userDetailMeShowService.getUserDetails(email);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponseDto(e.getMessage()));
+        }
+
+        // spec에 따른 응답 코드 (201 Created)와 함께 조회 결과 반환
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(responseDto);
+    }
+
+
+    // 내 정보 수정 (UserDetailUpdateService)
+    @PatchMapping("/details")
+    public ResponseEntity<ApiResponseDto> updateUserDetails(
+            @RequestBody @Valid UserDetailUpdateDTO updateDto,
+            HttpServletRequest request) {
+
+        // JWT 토큰을 "Authorization" 헤더에서 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 존재하지 않습니다."));
+        }
+
+        // JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+
+        // 토큰에서 사용자 식별자(이메일) 추출
+        String email = jwtTokenProvider.getUsernameFromJWT(token);
+
+        // 서비스 호출: 이메일을 기준으로 사용자 상세 정보를 수정
+        try {
+            userDetailMeUpdateService.updateUserDetails(updateDto, email);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponseDto(e.getMessage()));
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ApiResponseDto("내 디테일 정보가 수정되었습니다."));
+    }
+
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/UserDetailController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/UserDetailController.java
@@ -1,0 +1,68 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.ApiResponseDto;
+import com.taiso.bike_api.dto.UserDetailRequestDTO;
+import com.taiso.bike_api.security.JwtTokenProvider;
+import com.taiso.bike_api.service.UserDetailService;
+import com.taiso.bike_api.service.UserDetailMeTourokuService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/me")
+public class UserDetailController {
+
+    private final UserDetailService userDetailService;
+    private final UserDetailMeTourokuService userDetailMeTourokuService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public UserDetailController(UserDetailService userDetailService,
+                                UserDetailMeTourokuService userDetailMeTourokuService,
+                                JwtTokenProvider jwtTokenProvider
+                                ) {
+        this.userDetailService = userDetailService;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailMeTourokuService = userDetailMeTourokuService;
+    }
+
+    @PostMapping("/details")
+    public ResponseEntity<ApiResponseDto> registerUserDetails(
+            @RequestBody @Valid UserDetailRequestDTO requestDto,
+            HttpServletRequest request) {
+
+        // JWT 토큰을 "Authorization" 헤더에서 추출
+        String token = request.getHeader("Authorization");
+        if (token == null || token.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponseDto("토큰이 존재하지 않습니다."));
+        }
+
+        // JWT 토큰 검증
+        if (!jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponseDto("만료되거나 올바르지 않은 토큰 입니다."));
+        }
+
+        // 토큰에서 이메일(사용자 식별자) 추출
+        String email = jwtTokenProvider.getUsernameFromJWT(token);
+
+        // 서비스 호출: 이메일을 기반으로 사용자를 조회하고, 사용자 상세 정보를 등록함.
+        try {
+            userDetailMeTourokuService.registerUserDetails(requestDto, email);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponseDto(e.getMessage()));
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponseDto("내 디테일 정보가 등록되었습니다."));
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/domain/UserDetailEntity.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/domain/UserDetailEntity.java
@@ -62,8 +62,8 @@ public class UserDetailEntity {
     @Column(name = "birth_date")
     private LocalDateTime birthDate;
 
-    @Column(name = "bio", length = 500)
-    private String bio;
+    @Column(name = "vio", length = 500)
+    private String vio;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "gender", length = 10)
@@ -81,6 +81,9 @@ public class UserDetailEntity {
 
     @Column(name = "weight")
     private Integer weight;
+
+    @Column(name = "age")
+    private Integer age;
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(name = "user_tag",

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ApiResponseDto.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ApiResponseDto.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponseDto {
+    private String message;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinAcceptResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinAcceptResponseDTO.java
@@ -1,0 +1,23 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubJoinAcceptResponseDTO {
+    private Long clubId;
+    private Long userId;
+    private String userNickname;
+    private String participantStatus;
+    private String role;
+    private LocalDateTime joinedAt;
+    private String message;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinRejectResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinRejectResponseDTO.java
@@ -1,0 +1,23 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubJoinRejectResponseDTO {
+    private Long clubId;
+    private Long userId;
+    private String userNickname;
+    private String participantStatus;
+    private String role;
+    private LocalDateTime joinedAt;
+    private String message;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ClubJoinResponseDTO.java
@@ -1,0 +1,21 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubJoinResponseDTO {
+    private Long clubId;
+    private Long userId;
+    private String clubName;
+    private LocalDateTime joinedAt;
+    private String message;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/LightningResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/LightningResponseDTO.java
@@ -1,0 +1,27 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LightningResponseDTO {
+    private Long lightningId;
+    private String title;
+    private Long creatorId;
+    private String status; // 모집, 마감, 종료 등 (문자열 형태)
+    private LocalDateTime eventDate;
+    private Integer duration;
+    private Integer capacity;
+    private String address;
+    private List<LightningUserDTO> lightningUsers;
+    private List<LightningTagDTO> tags;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/LightningTagDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/LightningTagDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LightningTagDTO {
+    private String tag;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/LightningUserDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/LightningUserDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LightningUserDTO {
+    private Long userId;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailRequestDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailRequestDTO.java
@@ -1,7 +1,8 @@
 package com.taiso.bike_api.dto;
 
 
-
+import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,17 +14,23 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class UserDetailRequestDTO {
 
     private Long userId;
     private String userNickname;
-    private String bio;
+    private Integer age;
+    private String gender;
+    // 성별: "남자", "여자", "그외" (Entity의 Gender enum과 매핑)
+    private String vio;
     private String profileImg;
     private String backgroundImg;
+    private Integer height;
+    private Integer weight;
     private String level;
-    private String gender;
-
-
-
-
+    private Integer FTP;
+    // FTP (Functional Threshold Power)
+    private String phoneNumber;
+    private LocalDateTime birthDate;
+    // 생년월일 (LocalDateTime 형식, JSON에서는 ISO-8601 포맷 사용)
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.taiso.bike_api.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,12 @@ public class UserDetailResponseDTO {
     private String profileImg;
     private String backgroundImg;
     private String level;
+    private String fullName;
     private String gender;
-
+    private Integer age;
+    private Integer height;
+    private Integer weight;
+    private Integer FTP;
+    private String phoneNumber;
+    private LocalDateTime birthDate;
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailResponseDTO.java
@@ -17,7 +17,7 @@ public class UserDetailResponseDTO {
 
     private Long userId;
     private String userNickname;
-    private String bio;
+    private String vio;
     private String profileImg;
     private String backgroundImg;
     private String level;

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailUpdateDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserDetailUpdateDTO.java
@@ -1,0 +1,24 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDetailUpdateDTO {
+    private String fullName;
+    private String gender;       // "남자", "여자", "그외"
+    private Integer age;
+    private Integer height;
+    private Integer weight;
+    private Integer FTP;
+    private String phoneNumber;
+    private LocalDateTime birthDate;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/ClubMemberRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/ClubMemberRepository.java
@@ -4,9 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
+import com.taiso.bike_api.domain.ClubEntity;
 import com.taiso.bike_api.domain.ClubMemberEntity;
 import com.taiso.bike_api.domain.UserEntity;
-import com.taiso.bike_api.domain.ClubEntity;
 
 @Repository
 public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Long> {

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/ClubMemberRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/ClubMemberRepository.java
@@ -2,8 +2,13 @@ package com.taiso.bike_api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 import com.taiso.bike_api.domain.ClubMemberEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.domain.ClubEntity;
 
 @Repository
-public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Long> {}
+public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Long> {
+    Optional<ClubMemberEntity> findByUserAndClub(UserEntity user, ClubEntity club);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/ClubRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/ClubRepository.java
@@ -2,8 +2,10 @@ package com.taiso.bike_api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
+import java.util.Optional;
 import com.taiso.bike_api.domain.ClubEntity;
 
 @Repository
-public interface ClubRepository extends JpaRepository<ClubEntity, Long> {}
+public interface ClubRepository extends JpaRepository<ClubEntity, Long> {
+    Optional<ClubEntity> findByClubId(Long clubId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
@@ -1,0 +1,12 @@
+package com.taiso.bike_api.repository;
+
+import com.taiso.bike_api.domain.LightningUserEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LightningUserRepository extends JpaRepository<LightningUserEntity, Long> {
+    List<LightningUserEntity> findByUser(UserEntity user);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserDetailRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserDetailRepository.java
@@ -1,9 +1,9 @@
 package com.taiso.bike_api.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.taiso.bike_api.domain.UserDetailEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserDetailRepository extends JpaRepository<UserDetailEntity, Long> {
-    
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
@@ -1,0 +1,73 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.ClubEntity;
+import com.taiso.bike_api.domain.ClubMemberEntity;
+import com.taiso.bike_api.domain.ClubMemberEntity.ParticipantStatus;
+import com.taiso.bike_api.domain.ClubMemberEntity.Role;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.ClubJoinResponseDTO;
+import com.taiso.bike_api.repository.ClubMemberRepository;
+import com.taiso.bike_api.repository.ClubRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ClubMemberService {
+
+    private final ClubRepository clubRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public ClubMemberService(ClubRepository clubRepository,
+                             ClubMemberRepository clubMemberRepository,
+                             UserRepository userRepository) {
+        this.clubRepository = clubRepository;
+        this.clubMemberRepository = clubMemberRepository;
+        this.userRepository = userRepository;
+    }
+
+    public ClubJoinResponseDTO joinClub(Long clubId, String email) {
+        // 1. 클럽 존재 여부 확인
+        ClubEntity club = clubRepository.findById(clubId)
+            .orElseThrow(() -> new IllegalArgumentException("클럽이 존재하지 않습니다."));
+
+        // 2. 사용자 조회 (이메일 기준)
+        UserEntity user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 3. 기존 클럽 가입(또는 신청) 기록 확인
+        Optional<ClubMemberEntity> existingMembershipOpt = 
+                clubMemberRepository.findByUserAndClub(user, club);
+        if (existingMembershipOpt.isPresent()) {
+            ClubMemberEntity existing = existingMembershipOpt.get();
+            if (existing.getParticipantStatus() == ParticipantStatus.신청대기) {
+                throw new IllegalArgumentException("이미 해당 클럽에 참가 신청을 했습니다.");
+            } else if (existing.getParticipantStatus() == ParticipantStatus.승인 ||
+                       existing.getParticipantStatus() == ParticipantStatus.완료) {
+                throw new IllegalArgumentException("이미 해당 클럽에 참여했습니다.");
+            }
+        }
+
+        // 4. 새로운 클럽 가입 신청 생성 (참가 상태: 신청대기, 역할: 멤버)
+        ClubMemberEntity clubMember = ClubMemberEntity.builder()
+            .user(user)
+            .club(club)
+            .role(Role.멤버)
+            .participantStatus(ParticipantStatus.신청대기)
+            .build();
+
+        clubMemberRepository.save(clubMember);
+
+        // 5. 응답 DTO 생성 (clubMember.getJoinedAt()는 @CreationTimestamp로 자동 설정됨)
+        return ClubJoinResponseDTO.builder()
+                .clubId(club.getClubId())
+                .userId(user.getUserId())
+                .clubName(club.getClubName())
+                .joinedAt(clubMember.getJoinedAt())
+                .message("참가 신청이 완료되었습니다.")
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
@@ -9,6 +9,8 @@ import com.taiso.bike_api.domain.UserDetailEntity;
 
 import com.taiso.bike_api.dto.ClubJoinResponseDTO;
 import com.taiso.bike_api.dto.ClubJoinAcceptResponseDTO;
+import com.taiso.bike_api.dto.ClubJoinRejectResponseDTO;
+
 import com.taiso.bike_api.repository.ClubMemberRepository;
 import com.taiso.bike_api.repository.ClubRepository;
 import com.taiso.bike_api.repository.UserDetailRepository;
@@ -126,4 +128,62 @@ public class ClubMemberService {
                 .message("가입이 완료 되었습니다.")
                 .build();
     }
+
+    // 클럽 가입 거절
+    public ClubJoinRejectResponseDTO rejectClubJoin(Long clubId, Long userId, String adminEmail) {
+        // 1. 관리자(어드민) 권한 확인
+        UserEntity adminUser = userRepository.findByEmail(adminEmail)
+            .orElseThrow(() -> new IllegalArgumentException("Admin user not found"));
+        if (!adminUser.getRole().getRoleName().equalsIgnoreCase("ADMIN")) {
+            throw new IllegalArgumentException("관리자 권한이 필요합니다.");
+        }
+
+        // 2. 클럽 존재 여부 확인
+        ClubEntity club = clubRepository.findById(clubId)
+            .orElseThrow(() -> new IllegalArgumentException("클럽이 존재하지 않습니다."));
+
+        // 3. 대상 사용자 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 4. 클럽 멤버(가입 신청) 기록 조회
+        Optional<ClubMemberEntity> membershipOpt = clubMemberRepository.findByUserAndClub(targetUser, club);
+        ClubMemberEntity membership = membershipOpt.orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 5. 이미 승인 또는 완료된 가입 신청인 경우 거절 불가
+        if (membership.getParticipantStatus() == ParticipantStatus.승인 ||
+            membership.getParticipantStatus() == ParticipantStatus.완료) {
+            throw new IllegalArgumentException("넌 이미 클럽 가입이 승인되었단다.");
+        }
+
+        // 6. 가입 거절 처리: (신청대기 상태의 경우) 해당 가입 신청 기록 삭제
+        //    (삭제 전 정보를 응답용으로 보존)
+        ClubMemberEntity membershipInfo = ClubMemberEntity.builder()
+                .memberId(membership.getMemberId())
+                .user(membership.getUser())
+                .club(membership.getClub())
+                .role(membership.getRole())
+                .participantStatus(membership.getParticipantStatus())
+                .joinedAt(membership.getJoinedAt())
+                .build();
+
+        clubMemberRepository.delete(membership);
+
+        // 7. 대상 사용자의 닉네임 조회 (UserDetailEntity)
+        UserDetailEntity userDetail = userDetailRepository.findById(userId).orElse(null);
+        String nickname = (userDetail != null) ? userDetail.getUserNickname() : "";
+
+        // 8. 응답 DTO 생성 (메시지는 가입 신청 거절을 의미)
+        return ClubJoinRejectResponseDTO.builder()
+                .clubId(club.getClubId())
+                .userId(userId)
+                .userNickname(nickname)
+                .participantStatus(membershipInfo.getParticipantStatus().toString())
+                .role(membershipInfo.getRole().toString())
+                .joinedAt(membershipInfo.getJoinedAt())
+                .message("가입 신청이 거절되었습니다.")
+                .build();
+    }
+
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/ClubMemberService.java
@@ -5,9 +5,13 @@ import com.taiso.bike_api.domain.ClubMemberEntity;
 import com.taiso.bike_api.domain.ClubMemberEntity.ParticipantStatus;
 import com.taiso.bike_api.domain.ClubMemberEntity.Role;
 import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
+
 import com.taiso.bike_api.dto.ClubJoinResponseDTO;
+import com.taiso.bike_api.dto.ClubJoinAcceptResponseDTO;
 import com.taiso.bike_api.repository.ClubMemberRepository;
 import com.taiso.bike_api.repository.ClubRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
 import com.taiso.bike_api.repository.UserRepository;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,16 +23,20 @@ public class ClubMemberService {
     private final ClubRepository clubRepository;
     private final ClubMemberRepository clubMemberRepository;
     private final UserRepository userRepository;
+    private final UserDetailRepository userDetailRepository;
 
     @Autowired
     public ClubMemberService(ClubRepository clubRepository,
                              ClubMemberRepository clubMemberRepository,
-                             UserRepository userRepository) {
+                             UserRepository userRepository,
+                             UserDetailRepository userDetailRepository) {
         this.clubRepository = clubRepository;
         this.clubMemberRepository = clubMemberRepository;
         this.userRepository = userRepository;
+        this.userDetailRepository = userDetailRepository;
     }
 
+    // 클러 가입 신청
     public ClubJoinResponseDTO joinClub(Long clubId, String email) {
         // 1. 클럽 존재 여부 확인
         ClubEntity club = clubRepository.findById(clubId)
@@ -68,6 +76,54 @@ public class ClubMemberService {
                 .clubName(club.getClubName())
                 .joinedAt(clubMember.getJoinedAt())
                 .message("참가 신청이 완료되었습니다.")
+                .build();
+    }
+
+    // 클럽 가입 승인
+    public ClubJoinAcceptResponseDTO acceptClubJoin(Long clubId, Long userId, String adminEmail) {
+        // 1. 관리자(어드민) 권한 확인
+        UserEntity adminUser = userRepository.findByEmail(adminEmail)
+            .orElseThrow(() -> new IllegalArgumentException("Admin user not found"));
+        if (!adminUser.getRole().getRoleName().equalsIgnoreCase("ADMIN")) {
+            throw new IllegalArgumentException("관리자 권한이 필요합니다.");
+        }
+
+        // 2. 클럽 존재 여부 확인
+        ClubEntity club = clubRepository.findById(clubId)
+            .orElseThrow(() -> new IllegalArgumentException("클럽이 존재하지 않습니다."));
+
+        // 3. 대상 사용자의 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 4. 클럽 멤버(가입 신청) 기록 조회
+        Optional<ClubMemberEntity> membershipOpt = clubMemberRepository.findByUserAndClub(targetUser, club);
+        ClubMemberEntity membership = membershipOpt.orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 5. 이미 승인(또는 완료)된 가입 신청인지 확인
+        if (membership.getParticipantStatus() == ParticipantStatus.승인 ||
+            membership.getParticipantStatus() == ParticipantStatus.완료) {
+            throw new IllegalArgumentException("넌 이미 클럽 가입이 승인되었단다.");
+        }
+
+        // 6. 가입 신청 수락 처리: 참가 상태를 '승인'으로 변경
+        membership.setParticipantStatus(ParticipantStatus.승인);
+        clubMemberRepository.save(membership);
+
+        // 7. 대상 사용자의 닉네임 조회 (UserDetailEntity)
+        UserDetailEntity userDetail = userDetailRepository.findById(userId).orElse(null);
+        String nickname = (userDetail != null) ? userDetail.getUserNickname() : "";
+
+        // 8. 응답 DTO 생성 및 반환
+        return ClubJoinAcceptResponseDTO.builder()
+                .clubId(club.getClubId())
+                .userId(userId)
+                .userNickname(nickname)
+                .participantStatus(membership.getParticipantStatus().toString())
+                .role(membership.getRole().toString())
+                .joinedAt(membership.getJoinedAt())
+                .message("가입이 완료 되었습니다.")
                 .build();
     }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/LightningService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/LightningService.java
@@ -1,0 +1,98 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.LightningEntity;
+import com.taiso.bike_api.domain.LightningEntity.LightningStatus;
+import com.taiso.bike_api.domain.LightningUserEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.LightningResponseDTO;
+import com.taiso.bike_api.dto.LightningTagDTO;
+import com.taiso.bike_api.dto.LightningUserDTO;
+import com.taiso.bike_api.repository.LightningUserRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LightningService {
+
+    private final LightningUserRepository lightningUserRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public LightningService(LightningUserRepository lightningUserRepository,
+                            UserRepository userRepository) {
+        this.lightningUserRepository = lightningUserRepository;
+        this.userRepository = userRepository;
+    }
+
+    public List<LightningResponseDTO> getUserLightningEvents(String email, int statusParam) {
+        // 1. 현재 사용자 조회
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 2. 해당 사용자의 번개 참여 기록 조회
+        List<LightningUserEntity> lightningUserEntities = lightningUserRepository.findByUser(user);
+        if (lightningUserEntities.isEmpty()) {
+            throw new IllegalArgumentException("아무런 번개가 존재하지 않습니다.");
+        }
+
+        // 3. 쿼리 파라미터에 따른 번개 이벤트 상태 필터 설정
+        EnumSet<LightningStatus> statusFilter;
+        if (statusParam == 1) {
+            statusFilter = EnumSet.of(LightningStatus.모집, LightningStatus.마감);
+        } else if (statusParam == 3) {
+            statusFilter = EnumSet.of(LightningStatus.종료);
+        } else {
+            throw new IllegalArgumentException("Invalid status parameter");
+        }
+
+        // 4. 참여 기록에서 고유 번개 이벤트 추출 및 상태 필터 적용
+        List<LightningEntity> lightningEntities = lightningUserEntities.stream()
+                .map(LightningUserEntity::getLightning)
+                .distinct()
+                .filter(lightning -> statusFilter.contains(lightning.getStatus()))
+                .collect(Collectors.toList());
+
+        if (lightningEntities.isEmpty()) {
+            throw new IllegalArgumentException("아무런 번개가 존재하지 않습니다.");
+        }
+
+        // 5. 각 LightningEntity를 DTO로 변환
+        List<LightningResponseDTO> response = new ArrayList<>();
+        for (LightningEntity lightning : lightningEntities) {
+            // 해당 번개 이벤트의 모든 참여자(번개 사용자) 정보를 필터링
+            List<LightningUserDTO> lightningUserDtos = lightningUserEntities.stream()
+                    .filter(lu -> lu.getLightning().getLightningId().equals(lightning.getLightningId()))
+                    .map(lu -> LightningUserDTO.builder()
+                            .userId(lu.getUser().getUserId())
+                            .build())
+                    .collect(Collectors.toList());
+
+            // 번개 이벤트에 연결된 태그 정보를 DTO로 매핑
+            List<LightningTagDTO> tagDtos = lightning.getTags().stream()
+                    .map(tag -> LightningTagDTO.builder()
+                            .tag(tag.getName())
+                            .build())
+                    .collect(Collectors.toList());
+
+            LightningResponseDTO dto = LightningResponseDTO.builder()
+                    .lightningId(lightning.getLightningId())
+                    .title(lightning.getTitle())
+                    .creatorId(lightning.getCreatorId())
+                    .status(lightning.getStatus().toString())
+                    .eventDate(lightning.getEventDate())
+                    .duration(lightning.getDuration())
+                    .capacity(lightning.getCapacity())
+                    .address(lightning.getAddress())
+                    .lightningUsers(lightningUserDtos)
+                    .tags(tagDtos)
+                    .build();
+            response.add(dto);
+        }
+        return response;
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeShowService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeShowService.java
@@ -1,0 +1,47 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.UserDetailResponseDTO;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailMeShowService {
+
+    private final UserDetailRepository userDetailRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserDetailMeShowService(UserDetailRepository userDetailRepository,
+                             UserRepository userRepository) {
+        this.userDetailRepository = userDetailRepository;
+        this.userRepository = userRepository;
+    }
+
+    public UserDetailResponseDTO getUserDetails(String email) {
+        // 이메일로 사용자 조회
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Long userId = user.getUserId();
+
+        // 사용자 ID를 통해 상세 정보 조회 (UserDetailEntity의 @Id는 userId와 동일)
+        UserDetailEntity userDetail = userDetailRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User detail not found"));
+
+        // Entity의 필드를 DTO로 매핑 (gender는 Enum을 문자열로 변환)
+        return UserDetailResponseDTO.builder()
+                .fullName(userDetail.getFullName())
+                .gender(userDetail.getGender() != null ? userDetail.getGender().toString() : null)
+                .age(userDetail.getAge())
+                .height(userDetail.getHeight())
+                .weight(userDetail.getWeight())
+                .FTP(userDetail.getFTP())
+                .phoneNumber(userDetail.getPhoneNumber())
+                .birthDate(userDetail.getBirthDate())
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeTourokuService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeTourokuService.java
@@ -1,0 +1,57 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.domain.UserDetailEntity.Gender;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.UserDetailRequestDTO;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailMeTourokuService {
+
+    private final UserDetailRepository userDetailRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserDetailMeTourokuService(UserDetailRepository userDetailRepository,
+                             UserRepository userRepository) {
+        this.userDetailRepository = userDetailRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void registerUserDetails(UserDetailRequestDTO requestDto, String email) {
+        // 이메일로 사용자 엔티티 조회
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Long userId = user.getUserId(); // UserEntity의 PK 필드
+
+        // DTO의 데이터를 UserDetailEntity로 매핑
+        UserDetailEntity userDetail = new UserDetailEntity();
+        userDetail.setUserId(userId);
+        userDetail.setUser(user);
+        userDetail.setUserNickname(requestDto.getUserNickname());
+
+        // 전달받은 gender 문자열을 Enum으로 변환 (예: "남자", "여자", "그외")
+        try {
+            userDetail.setGender(Gender.valueOf(requestDto.getGender()));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("입력한 gender 값이 올바르지 않습니다.");
+        }
+
+        userDetail.setAge(requestDto.getAge());
+        userDetail.setHeight(requestDto.getHeight());
+        userDetail.setWeight(requestDto.getWeight());
+        userDetail.setFTP(requestDto.getFTP());
+        userDetail.setPhoneNumber(requestDto.getPhoneNumber());
+        userDetail.setBirthDate(requestDto.getBirthDate());
+
+        // 추가 필드 (예: bio, profileImg, backgroundImg 등)는 필요 시 설정
+
+        // UserDetailEntity를 데이터베이스에 저장
+        userDetailRepository.save(userDetail);
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeUpdateService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailMeUpdateService.java
@@ -1,0 +1,55 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.domain.UserDetailEntity.Gender;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.UserDetailUpdateDTO;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailMeUpdateService {
+
+    private final UserDetailRepository userDetailRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserDetailMeUpdateService(UserDetailRepository userDetailRepository,
+                             UserRepository userRepository) {
+        this.userDetailRepository = userDetailRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void updateUserDetails(UserDetailUpdateDTO updateDto, String email) {
+        // 이메일로 사용자 조회
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Long userId = user.getUserId();
+
+        // 사용자 ID를 통해 상세 정보 조회
+        UserDetailEntity userDetail = userDetailRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User detail not found"));
+
+        // DTO의 데이터를 Entity 필드에 업데이트
+        userDetail.setFullName(updateDto.getFullName());
+
+        try {
+            userDetail.setGender(Gender.valueOf(updateDto.getGender()));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("입력한 gender 값이 올바르지 않습니다.");
+        }
+
+        userDetail.setAge(updateDto.getAge());
+        userDetail.setHeight(updateDto.getHeight());
+        userDetail.setWeight(updateDto.getWeight());
+        userDetail.setFTP(updateDto.getFTP());
+        userDetail.setPhoneNumber(updateDto.getPhoneNumber());
+        userDetail.setBirthDate(updateDto.getBirthDate());
+
+        // 변경된 정보를 데이터베이스에 저장
+        userDetailRepository.save(userDetail);
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserDetailService.java
@@ -118,7 +118,7 @@ public class UserDetailService {
             userDetailResponseDTO = UserDetailResponseDTO.builder()
                     .userId(userDetail.getUserId())
                     .userNickname(userDetail.getUserNickname())
-                    .bio(userDetail.getBio())
+                    .vio(userDetail.getVio())
                     .profileImg(userDetail.getUserProfileImg())
                     .backgroundImg(userDetail.getUserBackgroundImg())
                     .build();


### PR DESCRIPTION
API-511-1_클럽 생성


<추가 사항>

- ClubCreateRequestDTO.java 추가
- LightningTagCategoryRepository.java 추가
(클럽 생성 시 요청된 태그 ID에 해당하는 태그 엔티티를 조회하기 위한 Repository입니다.)
(클럽 엔티티의 tags 필드는 LightningTagCategoryEntity와 Many-to-Many 관계로 매핑되어 있습니다.)
- ClubService.java 추가


<수정 사항>

- ClubRepository에 findByClubName 추가


<서비스 로직>

- 클럽 생성 로직을 담당합니다.
- 중복 클럽명 체크
- JWT 토큰에서 식별한 사용자를 클럽장으로 설정
- 요청된 태그 ID들을 이용해 해당 태그 엔티티들을 조회하여 클럽의 태그 Set에 추가
- 클럽 엔티티를 저장


1. DTO:
- ClubCreateRequestDto는 클럽 생성에 필요한 정보(이미지, 이름, 설명, 태그 ID 목록, 최대 인원)를 포함합니다.

2. Repository:
- ClubRepository는 클럽명을 기준으로 중복 체크를 위해 사용하며,
- LightningTagCategoryRepository는 요청된 태그 ID에 해당하는 태그 엔티티를 조회하는 데 사용합니다.

3. 컨트롤러:
- /clubs POST 엔드포인트에서 JWT 토큰 검증 후, 서비스에 요청 데이터를 전달하여 클럽을 생성합니다.

4. 서비스:
- 현재 사용자를 클럽장으로 설정하고, 요청 데이터와 태그 정보를 기반으로 새로운 클럽 엔티티를 생성한 후 저장합니다.
- 이와 같이 구성하면, 클라이언트가 Authorization 헤더에 JWT 토큰을 포함하여 POST /clubs 요청을 보내면, 중복 클럽명 체크 후 클럽이 생성되고 성공 메시지가 응답됩니다.