### PR TITLE
API-323-1_번개 참가 수락

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/LightningController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/LightningController.java
@@ -1,25 +1,29 @@
 package com.taiso.bike_api.controller;
+import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 
 import com.taiso.bike_api.dto.LightningGetRequestDTO;
 import com.taiso.bike_api.dto.LightningGetResponseDTO;
 import com.taiso.bike_api.dto.LightningRequestDTO;
 import com.taiso.bike_api.dto.LightningResponseDTO;
 import com.taiso.bike_api.service.LightningService;
+import com.taiso.bike_api.dto.LightningJoinAcceptResponseDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-
 
 
 @RestController
@@ -51,6 +55,35 @@ public class LightningController {
         
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(responseDTO);
     }
-    
+
+    // 번개 참가 수락
+    @PatchMapping("/join-requests/{lightningId}/{userId}")
+    @Operation(summary = "번개 참가 수락", description = "번개 이벤트 생성자(또는 관리자)가 특정 사용자의 참가 신청을 수락합니다.")
+    public ResponseEntity<?> acceptJoinRequest(
+            @PathVariable("lightningId") Long lightningId,
+            @PathVariable("userId") Long userId,
+            Authentication authentication) {
+
+        // SecurityFilterChain에서 인증된 사용자 정보를 Authentication 객체로 주입받습니다.
+        String requesterEmail = authentication.getName();
+
+        try {
+            LightningJoinAcceptResponseDTO responseDto =
+                    lightningService.acceptJoinRequest(lightningId, userId, requesterEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            if ("해당 사용자의 참가 신청이 존재하지 않습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("해당 사용자는 이미 모임에 승인되었습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
     
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/LightningJoinAcceptResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/LightningJoinAcceptResponseDTO.java
@@ -1,0 +1,22 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LightningJoinAcceptResponseDTO {
+    private Long lightningId;
+    private String title;
+    private Long userId;
+    private String username;
+    private String message;
+    private LocalDateTime joinedAt;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.taiso.bike_api.domain.LightningEntity;
 
+@Repository
 public interface LightningRepository extends JpaRepository<LightningEntity, Long>, JpaSpecificationExecutor<LightningEntity>{
     
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningTagCategoryRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningTagCategoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.LightningTagCategoryEntity;
 
+@Repository
 public interface LightningTagCategoryRepository extends JpaRepository<LightningTagCategoryEntity, Long> {
 
     Optional<LightningTagCategoryEntity> findByName(String tagName);

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
@@ -8,9 +8,11 @@ import com.taiso.bike_api.domain.LightningEntity;
 import com.taiso.bike_api.domain.LightningUserEntity;
 import com.taiso.bike_api.domain.UserEntity;
 
+@Repository
 public interface LightningUserRepository extends JpaRepository<LightningUserEntity, Long> {
 
-	void save(LightningEntity lightningEntity);
+	// void save(LightningEntity lightningEntity);
+	// 충돌로 인한 임시 주석 처리 ㅋ
 
 	Optional<LightningUserEntity> findByLightningAndUser(LightningEntity lightningEntityException,
 			UserEntity userEntityException);

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/RouteLikeRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/RouteLikeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.taiso.bike_api.domain.RouteLikeEntity;
+
 @Repository
 public interface RouteLikeRepository extends JpaRepository<RouteLikeEntity, Long> {
 

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/RoutePointRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/RoutePointRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.taiso.bike_api.domain.RouteEntity;
 import com.taiso.bike_api.domain.RoutePointEntity;
 
+@Repository
 public interface RoutePointRepository extends JpaRepository<RoutePointEntity, Long> {
         // route에 해당하는 포인트를 sequence 순으로 조회
     List<RoutePointEntity> findByRouteOrderBySequenceAsc(RouteEntity route);

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/RouteRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/RouteRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.taiso.bike_api.domain.RouteEntity;
 
+@Repository
 public interface RouteRepository extends JpaRepository<RouteEntity, Long>, JpaSpecificationExecutor<RouteEntity> {
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/RouteTagCategoryRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/RouteTagCategoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.RouteTagCategoryEntity;
 
+@Repository
 public interface RouteTagCategoryRepository extends JpaRepository<RouteTagCategoryEntity, Long> {
     Optional<RouteTagCategoryEntity> findByName(String name);
 } 

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserDetailRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserDetailRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.UserDetailEntity;
 
+@Repository
 public interface UserDetailRepository extends JpaRepository<UserDetailEntity, Long> {
     
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserRoleRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserRoleRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.UserRoleEntity;
 
+@Repository
 public interface UserRoleRepository extends JpaRepository<UserRoleEntity, Integer> {
     Optional<UserRoleEntity> findByRoleName(String roleName);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserStatusRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserStatusRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.UserStatusEntity;
 
+@Repository
 public interface UserStatusRepository extends JpaRepository<UserStatusEntity, Integer> {
     Optional<UserStatusEntity> findByStatusName(String statusName);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserTagCategoryRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserTagCategoryRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.taiso.bike_api.domain.UserTagCategoryEntity;
 
+@Repository
 public interface UserTagCategoryRepository extends JpaRepository<UserTagCategoryEntity, Long> {
     
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/LightningService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/LightningService.java
@@ -20,13 +20,16 @@ import com.taiso.bike_api.domain.LightningEntity.Level;
 import com.taiso.bike_api.domain.LightningEntity.Region;
 import com.taiso.bike_api.domain.LightningTagCategoryEntity;
 import com.taiso.bike_api.domain.LightningUserEntity;
+import com.taiso.bike_api.domain.LightningUserEntity.ParticipantStatus;
 import com.taiso.bike_api.domain.UserEntity;
 import com.taiso.bike_api.dto.LightningGetRequestDTO;
 import com.taiso.bike_api.dto.LightningGetResponseDTO;
 import com.taiso.bike_api.dto.LightningRequestDTO;
 import com.taiso.bike_api.dto.LightningResponseDTO;
 import com.taiso.bike_api.dto.ResponseComponentDTO;
+import com.taiso.bike_api.dto.LightningJoinAcceptResponseDTO;
 import com.taiso.bike_api.repository.LightningRepository;
+import com.taiso.bike_api.repository.LightningUserRepository;
 import com.taiso.bike_api.repository.LightningTagCategoryRepository;
 import com.taiso.bike_api.repository.RouteRepository;
 import com.taiso.bike_api.repository.UserRepository;
@@ -41,6 +44,8 @@ public class LightningService {
     
     @Autowired
     LightningRepository lightningRepository;
+
+    LightningUserRepository lightningUserRepository;
 
     @Autowired
     RouteRepository routeRepository;
@@ -173,4 +178,52 @@ public class LightningService {
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
         };
     }
+
+    
+    // 번개 참가 수락
+    public LightningJoinAcceptResponseDTO acceptJoinRequest(Long lightningId, Long userId, String requesterEmail) {
+        // 1. 번개 이벤트 존재 여부 확인
+        LightningEntity lightning = lightningRepository.findById(lightningId)
+                .orElseThrow(() -> new IllegalArgumentException("번개 이벤트가 존재하지 않습니다."));
+
+        // 2. 대상 사용자 조회
+        UserEntity targetUser = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 3. 번개 참가 신청(번개 사용자) 조회
+        LightningUserEntity joinRequest = lightningUserRepository.findByLightningAndUser(lightning, targetUser)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 참가 신청이 존재하지 않습니다."));
+
+        // 4. 이미 승인된 경우 에러 발생
+        if (joinRequest.getParticipantStatus() == ParticipantStatus.승인) {
+            throw new IllegalArgumentException("해당 사용자는 이미 모임에 승인되었습니다.");
+        }
+
+        // 5. (권한 체크) - 요청자가 번개 이벤트 생성자이거나, 관리자인지 확인
+        UserEntity requesterUser = userRepository.findByEmail(requesterEmail)
+                .orElseThrow(() -> new IllegalArgumentException("요청자 정보가 존재하지 않습니다."));
+
+        // 요청자가 관리자 역할("ADMIN")이거나, 이벤트 생성자(userId가 creatorId와 일치)여야 함
+        if (!requesterUser.getRole().getRoleName().equalsIgnoreCase("ADMIN") &&
+                !requesterUser.getUserId().equals(lightning.getCreatorId())) {
+            throw new IllegalArgumentException("참가 수락 권한이 없습니다.");
+        }
+
+        // 6. 참가 상태 변경: 신청대기 -> 승인
+        joinRequest.setParticipantStatus(ParticipantStatus.승인);
+        joinRequest.setJoinedAt(LocalDateTime.now());
+        lightningUserRepository.save(joinRequest);
+
+        // 7. 응답 DTO 구성 (여기서는 username으로 대상 사용자의 이메일을 사용)
+        String username = targetUser.getEmail();
+        return LightningJoinAcceptResponseDTO.builder()
+                .lightningId(lightning.getLightningId())
+                .title(lightning.getTitle())
+                .userId(targetUser.getUserId())
+                .username(username)
+                .message("번개 참가를 수락했습니다.")
+                .joinedAt(joinRequest.getJoinedAt())
+                .build();
+    }
+
 }


### PR DESCRIPTION
API-323-1_번개 참가 수락 요약

<개요>

- jwt 인증 컨트롤러 단에서 헤더 to 쿠키 인증 방식으로 변경
- 2025-02-24 main branch 기준 추가


<추가 사항>

- LightningJoinAcceptResponseDTO 추가


<수정 사항>

- LightningUserEntity에 rejected_at 행 추가(API 명세서에 없어서 API 명세서도 추가)
- LightningUserEntity 에서 충돌 코드 임시 주석처리 리팩토링 때 정리 ㄱ
// void save(LightningEntity lightningEntity);
- LightningController 로직 추가
- LightningService 로직 추가


<서비스 로직>

1. 컨트롤러 (LightningController):

- PATCH 엔드포인트 /lightnings/join-requests/{lightningId}/{userId}를 통해 번개 참가 수락 요청을 처리합니다.
- JWT 검증은 SecurityFilterChain에서 완료되며, 컨트롤러는 Authentication 객체를 주입받아 현재 요청자의 식별자(예: 이메일)를 사용합니다.
- 성공 시 전용 DTO(LightningJoinAcceptResponseDto)를 응답하고, 오류 발생 시 단순 메시지 Map을 통해 적절한 HTTP 상태 코드와 함께 에러 메시지를 반환합니다.

2. 서비스 (LightningService):

- 번개 이벤트(LightningEntity)와 대상 사용자의 번개 참가 신청(LightningUserEntity)을 조회합니다.
- 참가 신청이 존재하지 않거나 이미 승인된 경우 예외를 발생시킵니다.
- 참가 신청 상태를 승인(ParticipantStatus.승인)으로 변경하고, 승인 시각을 갱신한 후 저장합니다.
- 최종적으로 승인된 정보를 기반으로 응답 - DTO(LightningJoinAcceptResponseDto)를 생성하여 반환합니다.

3. DTO (LightningJoinAcceptResponseDto):

- 응답 데이터에는 번개 ID, 이벤트 제목, 대상 사용자 ID, 사용자 이름(또는 식별자), 승인 메시지, 승인 시각 등이 포함됩니다.

4. Repository (LightningUserRepository 등):

- 번개 참가 신청을 조회하기 위한 메서드를 제공하며, findByLightningAndUser와 같은 메서드를 통해 특정 이벤트와 사용자에 대한 참가 신청을 조회합니다.