### PR TITLE
API-441-1_내가 작성한 회원 리뷰 조회

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
@@ -1,0 +1,43 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.UserReviewRequestDTO;
+import com.taiso.bike_api.service.UserReviewService;
+import java.util.Collections;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/lightnings")
+public class UserReviewController {
+
+    private final UserReviewService userReviewService;
+
+    @Autowired
+    public UserReviewController(UserReviewService userReviewService) {
+        this.userReviewService = userReviewService;
+    }
+
+    @PostMapping("/{lightningId}/reviews/{userId}")
+    public ResponseEntity<?> createUserReview(
+            @PathVariable("lightningId") Long lightningId,
+            @PathVariable("userId") Long reviewedId,
+            @RequestBody @Valid UserReviewRequestDTO requestDto,
+            Authentication authentication) {
+
+        // JWT 인증이 완료된 상태에서 Authentication 객체를 통해 리뷰어의 이메일(식별자)를 추출합니다.
+        String reviewerEmail = authentication.getName();
+
+        try {
+            userReviewService.createReview(lightningId, reviewedId, reviewerEmail, requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(Collections.singletonMap("message", "해당 회원에 대한 리뷰가 등록되었습니다."));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewRequestDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewRequestDTO.java
@@ -1,0 +1,18 @@
+package com.taiso.bike_api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserReviewRequestDTO {
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    private String reviewContent;
+
+    @NotNull(message = "리뷰 태그는 필수입니다.")
+    private String reviewTag; // EXCELLENT, GOOD, AVERAGE, POOR 등의 값 (대소문자 무관)
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
@@ -1,10 +1,9 @@
 package com.taiso.bike_api.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-
 import com.taiso.bike_api.domain.LightningEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface LightningRepository extends JpaRepository<LightningEntity, Long>, JpaSpecificationExecutor<LightningEntity>{
-    
+@Repository
+public interface LightningRepository extends JpaRepository<LightningEntity, Long> {
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
@@ -1,0 +1,10 @@
+package com.taiso.bike_api.repository;
+
+import com.taiso.bike_api.domain.UserReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserReviewRepository extends JpaRepository<UserReviewEntity, Long> {
+    // 추가 쿼리가 필요하면 여기에 정의
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
@@ -1,0 +1,62 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.LightningEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.domain.UserReviewEntity;
+import com.taiso.bike_api.domain.UserReviewEntity.ReviewTag;
+import com.taiso.bike_api.dto.UserReviewRequestDTO;
+import com.taiso.bike_api.repository.LightningRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import com.taiso.bike_api.repository.UserReviewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserReviewService {
+
+    private final LightningRepository lightningRepository;
+    private final UserRepository userRepository;
+    private final UserReviewRepository userReviewRepository;
+
+    @Autowired
+    public UserReviewService(LightningRepository lightningRepository,
+                             UserRepository userRepository,
+                             UserReviewRepository userReviewRepository) {
+        this.lightningRepository = lightningRepository;
+        this.userRepository = userRepository;
+        this.userReviewRepository = userReviewRepository;
+    }
+
+    public void createReview(Long lightningId, Long reviewedId, String reviewerEmail, UserReviewRequestDTO requestDto) {
+        // 1. 번개 이벤트 조회
+        LightningEntity lightning = lightningRepository.findById(lightningId)
+                .orElseThrow(() -> new IllegalArgumentException("아무런 번개가 존재하지 않습니다."));
+
+        // 2. 리뷰어(현재 사용자) 조회
+        UserEntity reviewer = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰어 정보가 존재하지 않습니다."));
+
+        // 3. 리뷰 대상자 조회
+        UserEntity reviewed = userRepository.findById(reviewedId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰 대상 사용자 정보가 존재하지 않습니다."));
+
+        // 4. 리뷰 태그 변환 (대소문자 구분 없이 변환)
+        ReviewTag reviewTag;
+        try {
+            reviewTag = ReviewTag.valueOf(requestDto.getReviewTag().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 리뷰 태그입니다.");
+        }
+
+        // 5. 리뷰 엔티티 생성 및 저장
+        UserReviewEntity review = UserReviewEntity.builder()
+                .reviewContent(requestDto.getReviewContent())
+                .reviewer(reviewer)
+                .reviewed(reviewed)
+                .lightning(lightning)
+                .reviewTag(reviewTag)
+                .build();
+
+        userReviewRepository.save(review);
+    }
+}


### PR DESCRIPTION
API-441-1_내가 작성한 회원 리뷰 조회


<추가 사항>

- UserReviewRequestDTO 추가
- UserReviewRepository 추가
- LightningRepository 추가
- UserReviewController
- UserReviewService 추가

<수정 사항>


<서비스 로직>

1. DTO

- UserReviewRequestDTO는 리뷰 등록 시 클라이언트가 전달하는 리뷰 내용과 태그를 포함합니다.

2. Repository

- UserReviewRepository와 LightningRepository를 사용하여 각각 리뷰와 번개 이벤트 정보를 조회 및 저장합니다.

3. 컨트롤러
- /lightnings/{lightningId}/reviews/{userId} 엔드포인트에서 Authentication 객체를 통해 JWT 인증이 완료된 사용자의 이메일(리뷰어)을 추출하고,
- 서비스에 필요한 파라미터(번개 ID, 리뷰 대상 사용자 ID, 리뷰어 이메일, 요청 DTO)를 전달합니다.
- 성공 시 "해당 회원에 대한 리뷰가 등록되었습니다." 메시지를 반환하며, 오류 발생 시 적절한 상태 코드와 메시지를 Map 형태로 응답합니다.

4. 서비스
- 서비스 레이어에서는 번개 이벤트, 리뷰어, 리뷰 대상자를 각각 조회하고,
- 리뷰 태그를 enum으로 변환한 후 새로운 UserReviewEntity를 생성, 저장합니다.

- 번개 이벤트 조회:
	- 주어진 lightningId로 LightningEntity를 조회합니다. 없으면 "아무런 번개가 존재하지 않습니다." 예외 발생.


리뷰어 조회:
	- Authentication에서 추출한 이메일로 UserEntity(리뷰어)를 조회합니다.

리뷰 대상자 조회:
	- Path Parameter의 reviewedId를 이용하여 리뷰 대상 UserEntity를 조회합니다.

리뷰 태그 검증 및 변환:
	- requestDto.reviewTag 문자열을 UserReviewEntity.ReviewTag enum으로 변환합니다.
	- 변환에 실패하면 "유효하지 않은 리뷰 태그입니다." 예외 발생.

리뷰 엔티티 생성 및 저장:
	- 위 정보들을 기반으로 UserReviewEntity를 생성한 후 저장합니다.