### PR TITLE
API-442-1_내가 작성한 회원 리뷰 조회 요약

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
@@ -1,0 +1,45 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.UserReviewResponseDTO;
+import com.taiso.bike_api.service.UserReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class UserReviewController {
+
+    private final UserReviewService userReviewService;
+
+    @Autowired
+    public UserReviewController(UserReviewService userReviewService) {
+        this.userReviewService = userReviewService;
+    }
+
+    @GetMapping("/{userId}/lightnings/{lightningId}/reviews")
+    @Operation(summary = "내가 작성한 회원 리뷰 조회",
+            description = "내 예약/완료 번개 정보 조회 시, 리뷰가 작성되어 있다면 해당 리뷰들을 조회합니다. " +
+                    "review_db에서 reviewed_id가 해당 userId인 리뷰를, 주어진 lightningId로 필터링합니다.")
+    public ResponseEntity<?> getUserReviews(
+            @PathVariable("userId") Long reviewedId,
+            @PathVariable("lightningId") Long lightningId,
+            Authentication authentication) {
+
+        // (선택사항) 인증된 사용자가 조회 대상과 일치하는지 확인할 수 있습니다.
+        // 예: if (!authentication.getName().equals( ... )) { ... }
+
+        try {
+            List<UserReviewResponseDTO> reviews = userReviewService.getUserReviews(reviewedId, lightningId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(reviews);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ReviewedUserDetailDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ReviewedUserDetailDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewedUserDetailDTO {
+    private Long userId;
+    private String userProfileImg;
+    private String userNickname;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewResponseDTO.java
@@ -1,0 +1,20 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserReviewResponseDTO {
+    private Long lightningId;
+    private Long reviewId;
+    private Long reviewerId;
+    private Long reviewedId;
+    private String reviewContent;
+    private LocalDateTime reviewDate;  // 생성 시각(생성일)
+    private String reviewTag;
+    private ReviewedUserDetailDTO reviewedUserDetail;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
@@ -1,0 +1,11 @@
+package com.taiso.bike_api.repository;
+
+import com.taiso.bike_api.domain.UserReviewEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserReviewRepository extends JpaRepository<UserReviewEntity, Long> {
+    List<UserReviewEntity> findByReviewed_UserIdAndLightning_LightningId(Long reviewedUserId, Long lightningId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
@@ -1,0 +1,60 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.UserReviewEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.dto.ReviewedUserDetailDTO;
+import com.taiso.bike_api.dto.UserReviewResponseDTO;
+import com.taiso.bike_api.repository.UserReviewRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserReviewService {
+
+    private final UserReviewRepository userReviewRepository;
+    private final UserDetailRepository userDetailRepository;
+
+    @Autowired
+    public UserReviewService(UserReviewRepository userReviewRepository,
+                             UserDetailRepository userDetailRepository) {
+        this.userReviewRepository = userReviewRepository;
+        this.userDetailRepository = userDetailRepository;
+    }
+
+    public List<UserReviewResponseDTO> getUserReviews(Long reviewedId, Long lightningId) {
+        List<UserReviewEntity> reviews = userReviewRepository
+                .findByReviewed_UserIdAndLightning_LightningId(reviewedId, lightningId);
+
+        if (reviews.isEmpty()) {
+            throw new IllegalArgumentException("해당 리뷰가 존재하지 않습니다.");
+        }
+
+        return reviews.stream().map(review -> {
+            // 리뷰 대상자 상세 정보 조회
+            UserDetailEntity userDetail = userDetailRepository.findById(review.getReviewed().getUserId())
+                    .orElse(null);
+            ReviewedUserDetailDTO reviewedUserDetail = null;
+            if (userDetail != null) {
+                reviewedUserDetail = com.taiso.bike_api.dto.ReviewedUserDetailDTO.builder()
+                        .userId(userDetail.getUserId())
+                        .userProfileImg(userDetail.getUserProfileImg())
+                        .userNickname(userDetail.getUserNickname())
+                        .build();
+            }
+
+            return UserReviewResponseDTO.builder()
+                    .lightningId(review.getLightning().getLightningId())
+                    .reviewId(review.getReviewId())
+                    .reviewerId(review.getReviewer().getUserId())
+                    .reviewedId(review.getReviewed().getUserId())
+                    .reviewContent(review.getReviewContent())
+                    .reviewDate(review.getCreatedAt())
+                    .reviewTag(review.getReviewTag().toString())
+                    .reviewedUserDetail(reviewedUserDetail)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
API-442-1_내가 작성한 회원 리뷰 조회 요약


<추가 사항>

- ReviewedUserDetailDTO
- UserReviewResponseDTO
- UserReviewRepository
- UserReviewController
- UserReviewService

<수정 사항>


<서비스 로직>

- 이 예제에서는 URL에 두 개의 경로 변수(내 리뷰 대상인 회원의 ID와 번개 이벤트 ID)를 사용하여,
"내가 작성한 리뷰" 즉, review_db에서 reviewed_id가 해당 사용자인 리뷰를 조회하도록 합니다.
- 리뷰에 포함될 리뷰 대상자의 상세 정보는 UserDetailEntity에서 조회합니다.


1. DTO

- ReviewedUserDetailDTO: 리뷰 대상자의 상세 정보를 담음 (userId, userProfileImg, userNickname).
- UserReviewResponseDTO: 리뷰의 주요 정보(번개 ID, 리뷰 ID, 리뷰어/리뷰 대상자 ID, 리뷰 내용, 리뷰 생성일, 리뷰 태그)와 함께 리뷰 대상자 상세 정보를 포함.

2. Repository

- UserReviewRepository에 reviewed_id와 lightning_id를 기준으로 리뷰 목록을 조회하는 메서드를 추가함.

2. 컨트롤러

- /users/{userId}/lightnings/{lightningId}/reviews 엔드포인트를 통해 JWT 인증(쿠키 기반)이 완료된 상태에서 현재 사용자의 정보를 활용하여 리뷰 목록을 조회.
- 오류 발생 시 단순 Map으로 메시지를 반환.

3. 서비스

- UserReviewService는 리뷰 DB에서 reviewed_id와 lightning_id에 해당하는 리뷰들을 조회한 후, 각 엔티티를 응답 DTO로 변환하고, 리뷰 대상자의 상세 정보를 UserDetailRepository에서 조회하여 포함.