### PR TITLE
API-442-2_내 완료 번개 참여회원 리뷰 작성화면 요약

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/LightningReviewController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/LightningReviewController.java
@@ -1,0 +1,46 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.LightningReviewWriteScreenDTO;
+import com.taiso.bike_api.service.LightningReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/lightnings")
+public class LightningReviewController {
+
+    private final LightningReviewService lightningReviewService;
+
+    @Autowired
+    public LightningReviewController(LightningReviewService lightningReviewService) {
+        this.lightningReviewService = lightningReviewService;
+    }
+
+    @GetMapping("/{lightningId}/reviews")
+    @Operation(summary = "내 완료 번개 참여회원 리뷰 작성화면",
+            description = "번개 종료 후, 현재 사용자가 아직 리뷰를 작성하지 않은 참여 회원들의 정보를 조회합니다.")
+    public ResponseEntity<?> getReviewWriteScreen(
+            @PathVariable("lightningId") Long lightningId,
+            Authentication authentication) {
+
+        // 인증 객체가 없으면 UNAUTHORIZED
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Collections.singletonMap("message", "토큰이 없엉."));
+        }
+        String reviewerEmail = authentication.getName();
+        try {
+            List<LightningReviewWriteScreenDTO> dtos = lightningReviewService.getReviewWriteScreen(lightningId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.OK).body(dtos);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/UserReviewController.java
@@ -1,0 +1,45 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.UserReviewResponseDTO;
+import com.taiso.bike_api.service.UserReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class UserReviewController {
+
+    private final UserReviewService userReviewService;
+
+    @Autowired
+    public UserReviewController(UserReviewService userReviewService) {
+        this.userReviewService = userReviewService;
+    }
+
+    @GetMapping("/{userId}/lightnings/{lightningId}/reviews")
+    @Operation(summary = "내가 작성한 회원 리뷰 조회",
+            description = "내 예약/완료 번개 정보 조회 시, 리뷰가 작성되어 있다면 해당 리뷰들을 조회합니다. " +
+                    "review_db에서 reviewed_id가 해당 userId인 리뷰를, 주어진 lightningId로 필터링합니다.")
+    public ResponseEntity<?> getUserReviews(
+            @PathVariable("userId") Long reviewedId,
+            @PathVariable("lightningId") Long lightningId,
+            Authentication authentication) {
+
+        // (선택사항) 인증된 사용자가 조회 대상과 일치하는지 확인할 수 있습니다.
+        // 예: if (!authentication.getName().equals( ... )) { ... }
+
+        try {
+            List<UserReviewResponseDTO> reviews = userReviewService.getUserReviews(reviewedId, lightningId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(reviews);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/LightningReviewWriteScreenDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/LightningReviewWriteScreenDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LightningReviewWriteScreenDTO {
+    private Long lightningId;
+    private Long userId;              // 참여 회원의 사용자 ID
+    private String participantStatus; // 참여 상태 (예: "완료")
+    private String role;              // 역할 (예: "참여자")
+    private ReviewedUserDetailDTO userDetail; // 회원 상세 정보
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/ReviewedUserDetailDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/ReviewedUserDetailDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewedUserDetailDTO {
+    private Long userId;
+    private String userProfileImg;
+    private String userNickname;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/UserReviewResponseDTO.java
@@ -1,0 +1,20 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserReviewResponseDTO {
+    private Long lightningId;
+    private Long reviewId;
+    private Long reviewerId;
+    private Long reviewedId;
+    private String reviewContent;
+    private LocalDateTime reviewDate;  // 생성 시각(생성일)
+    private String reviewTag;
+    private ReviewedUserDetailDTO reviewedUserDetail;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningUserRepository.java
@@ -1,5 +1,6 @@
 package com.taiso.bike_api.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,7 @@ public interface LightningUserRepository extends JpaRepository<LightningUserEnti
 			UserEntity userEntityException);
 
 	Optional<LightningUserEntity> findByLightning_LightningIdAndUser_UserId(Long lightningId, Long userId);
+
+	List<LightningUserEntity> findByLightning_LightningId(Long lightningId);
+
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
@@ -1,0 +1,11 @@
+package com.taiso.bike_api.repository;
+
+import com.taiso.bike_api.domain.UserReviewEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserReviewRepository extends JpaRepository<UserReviewEntity, Long> {
+    List<UserReviewEntity> findByReviewed_UserIdAndLightning_LightningId(Long reviewedUserId, Long lightningId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/UserReviewRepository.java
@@ -2,10 +2,13 @@ package com.taiso.bike_api.repository;
 
 import com.taiso.bike_api.domain.UserReviewEntity;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserReviewRepository extends JpaRepository<UserReviewEntity, Long> {
     List<UserReviewEntity> findByReviewed_UserIdAndLightning_LightningId(Long reviewedUserId, Long lightningId);
+    Optional<UserReviewEntity> findByLightning_LightningIdAndReviewer_UserIdAndReviewed_UserId(Long lightningId, Long reviewerId, Long reviewedId);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/LightningReviewService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/LightningReviewService.java
@@ -1,0 +1,97 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.LightningEntity;
+import com.taiso.bike_api.domain.LightningUserEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.domain.UserReviewEntity;
+import com.taiso.bike_api.dto.LightningReviewWriteScreenDTO;
+import com.taiso.bike_api.dto.ReviewedUserDetailDTO;
+import com.taiso.bike_api.repository.LightningRepository;
+import com.taiso.bike_api.repository.LightningUserRepository;
+import com.taiso.bike_api.repository.UserReviewRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LightningReviewService {
+
+    private final LightningRepository lightningRepository;
+    private final LightningUserRepository lightningUserRepository;
+    private final UserReviewRepository userReviewRepository;
+    private final UserRepository userRepository;
+    private final UserDetailRepository userDetailRepository;
+
+    @Autowired
+    public LightningReviewService(LightningRepository lightningRepository,
+                                  LightningUserRepository lightningUserRepository,
+                                  UserReviewRepository userReviewRepository,
+                                  UserRepository userRepository,
+                                  UserDetailRepository userDetailRepository) {
+        this.lightningRepository = lightningRepository;
+        this.lightningUserRepository = lightningUserRepository;
+        this.userReviewRepository = userReviewRepository;
+        this.userRepository = userRepository;
+        this.userDetailRepository = userDetailRepository;
+    }
+
+    public List<LightningReviewWriteScreenDTO> getReviewWriteScreen(Long lightningId, String reviewerEmail) {
+        // 1. 번개 이벤트 조회
+        LightningEntity lightning = lightningRepository.findById(lightningId)
+                .orElseThrow(() -> new IllegalArgumentException("아무런 번개가 존재하지 않습니다."));
+
+        // 2. 현재 사용자(리뷰어) 조회
+        Long reviewerId = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰어 정보를 찾을 수 없습니다."))
+                .getUserId();
+
+        // 3. 해당 번개 이벤트의 참여 회원 조회
+        List<LightningUserEntity> participants = lightningUserRepository.findByLightning_LightningId(lightningId);
+        if (participants.isEmpty()) {
+            throw new IllegalArgumentException("아무런 번개가 존재하지 않습니다.");
+        }
+
+        // 4. 리뷰 미작성 참여 회원 필터링: 현재 리뷰어가 아직 리뷰를 작성하지 않은 회원만 선택
+        List<LightningReviewWriteScreenDTO> dtos = participants.stream()
+                .filter(lu -> {
+                    // 리뷰 대상은 현재 사용자가 아니고, 참여 상태가 "완료"인 회원만 포함
+                    return !lu.getUser().getUserId().equals(reviewerId)
+                            && lu.getParticipantStatus().toString().equals("완료");
+                })
+                .filter(lu -> {
+                    // 현재 리뷰어가 해당 회원에 대해 이미 리뷰를 작성했는지 확인
+                    Optional<UserReviewEntity> reviewOpt = userReviewRepository.findByLightning_LightningIdAndReviewer_UserIdAndReviewed_UserId(
+                            lightningId, reviewerId, lu.getUser().getUserId());
+                    return !reviewOpt.isPresent();
+                })
+                .map(lu -> {
+                    // 각 참여 회원의 상세 정보를 조회 (UserDetailEntity)
+                    UserDetailEntity detail = userDetailRepository.findById(lu.getUser().getUserId()).orElse(null);
+                    ReviewedUserDetailDTO userDetailDTO = null;
+                    if (detail != null) {
+                        userDetailDTO = ReviewedUserDetailDTO.builder()
+                                .userId(detail.getUserId())
+                                .userNickname(detail.getUserNickname())
+                                .userProfileImg(detail.getUserProfileImg())
+                                .build();
+                    }
+                    return LightningReviewWriteScreenDTO.builder()
+                            .lightningId(lightning.getLightningId())
+                            .userId(lu.getUser().getUserId())
+                            .participantStatus(lu.getParticipantStatus().toString())
+                            .role(lu.getRole().toString())
+                            .userDetail(userDetailDTO)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        if (dtos.isEmpty()) {
+            throw new IllegalArgumentException("리뷰를 작성할 회원이 존재하지 않습니다.");
+        }
+        return dtos;
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/UserReviewService.java
@@ -1,0 +1,60 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.UserReviewEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
+import com.taiso.bike_api.dto.ReviewedUserDetailDTO;
+import com.taiso.bike_api.dto.UserReviewResponseDTO;
+import com.taiso.bike_api.repository.UserReviewRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserReviewService {
+
+    private final UserReviewRepository userReviewRepository;
+    private final UserDetailRepository userDetailRepository;
+
+    @Autowired
+    public UserReviewService(UserReviewRepository userReviewRepository,
+                             UserDetailRepository userDetailRepository) {
+        this.userReviewRepository = userReviewRepository;
+        this.userDetailRepository = userDetailRepository;
+    }
+
+    public List<UserReviewResponseDTO> getUserReviews(Long reviewedId, Long lightningId) {
+        List<UserReviewEntity> reviews = userReviewRepository
+                .findByReviewed_UserIdAndLightning_LightningId(reviewedId, lightningId);
+
+        if (reviews.isEmpty()) {
+            throw new IllegalArgumentException("해당 리뷰가 존재하지 않습니다.");
+        }
+
+        return reviews.stream().map(review -> {
+            // 리뷰 대상자 상세 정보 조회
+            UserDetailEntity userDetail = userDetailRepository.findById(review.getReviewed().getUserId())
+                    .orElse(null);
+            ReviewedUserDetailDTO reviewedUserDetail = null;
+            if (userDetail != null) {
+                reviewedUserDetail = com.taiso.bike_api.dto.ReviewedUserDetailDTO.builder()
+                        .userId(userDetail.getUserId())
+                        .userProfileImg(userDetail.getUserProfileImg())
+                        .userNickname(userDetail.getUserNickname())
+                        .build();
+            }
+
+            return UserReviewResponseDTO.builder()
+                    .lightningId(review.getLightning().getLightningId())
+                    .reviewId(review.getReviewId())
+                    .reviewerId(review.getReviewer().getUserId())
+                    .reviewedId(review.getReviewed().getUserId())
+                    .reviewContent(review.getReviewContent())
+                    .reviewDate(review.getCreatedAt())
+                    .reviewTag(review.getReviewTag().toString())
+                    .reviewedUserDetail(reviewedUserDetail)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
API-442-2_내 완료 번개 참여회원 리뷰 작성화면 요약


<추가 사항>

- LightningReviewWriteScreenDTO
- LightningReviewController
- LightningReviewService


<수정 사항>


<서비스 로직>


1. DTO

- ReviewedUserDetailDTO는 리뷰 대상 회원의 기본 정보를 담습니다.
- LightningReviewWriteScreenDTO는 각 참여 회원에 대한 번개 이벤트 정보와 함께, 현재 사용자가 아직 리뷰를 작성하지 않은 회원의 정보를 반환합니다.


2. Repository

- LightningUserRepository의 findByLightning_LightningId 메서드를 사용해 번개 이벤트의 모든 참여 회원을 조회합니다.
- UserReviewRepository의 메서드를 통해 특정 번개 이벤트에 대해 현재 리뷰어가 이미 작성한 리뷰가 있는지 확인합니다.


3. 컨트롤러

- GET /lightnings/{lightningId}/reviews 엔드포인트에서 Authentication 객체를 통해 현재 사용자의 정보를 받아 서비스에 전달합니다.
- 결과가 없으면 적절한 오류 메시지와 함께 400 Bad Request를 반환합니다.


4. 서비스

- 지정된 번개 이벤트와 현재 리뷰어를 기반으로, 참여 회원들 중 아직 리뷰가 작성되지 않은 회원들을 필터링하여 DTO로 변환하고 반환합니다.