### PR TITLE
API-611-1_북마크 회원 등록

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,0 +1,48 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.service.BookmarkService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/users")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Autowired
+    public BookmarkController(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    // 북마크 회원 등록
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> createBookmark(@PathVariable("userId") Long targetUserId,
+                                            Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 식별자(이메일) 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkResponseDTO responseDTO = bookmarkService.createBookmark(targetUserId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // 에러에 따른 상태 코드를 반환합니다.
+            if ("대상 회원을 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 회원입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkResponseDTO {
+    private Long bookmarkId;
+    private Long userId;         // 북마크를 등록한 사용자
+    private Long targetUserId;   // 북마크 대상 사용자
+    private LocalDateTime createdAt;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.taiso.bike_api.repository;
 
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.taiso.bike_api.domain.BookmarkEntity;
-
 @Repository
-public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {}
+public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
+    Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -1,0 +1,56 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public BookmarkService(BookmarkRepository bookmarkRepository, UserRepository userRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 북마크 회원 등록
+    public BookmarkResponseDTO createBookmark(Long targetUserId, String reviewerEmail) {
+        // 현재 북마크를 등록하는 사용자 조회 (로그인한 사용자)
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("북마크 요청이 잘못됐습니다."));
+
+        // 타깃 유저(북마크 대상) 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 회원을 찾을 수 없습니다."));
+
+        // 이미 북마크한 회원인지 확인
+        Optional<BookmarkEntity> existingBookmark = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.USER, targetUserId);
+        if (existingBookmark.isPresent()) {
+            throw new IllegalArgumentException("이미 북마크한 회원입니다.");
+        }
+
+        // 북마크 엔티티 생성 및 저장
+        BookmarkEntity bookmark = BookmarkEntity.builder()
+                .user(user)
+                .targetType(BookmarkType.USER)
+                .targetId(targetUserId)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        return BookmarkResponseDTO.builder()
+                .bookmarkId(bookmark.getBookmarkId())
+                .userId(user.getUserId())
+                .targetUserId(targetUserId)
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
API-611-1_북마크 회원 등록 요약


<추가 사항>

- BookmarkResponseDTO
- BookmarkService
- BookmarkController


<수정 사항>


<서비스 로직>

1. DTO

- BookmarkResponseDTO는 북마크 등록 후 응답에 필요한 회원 ID, 대상 회원 ID, 북마크 고유 ID 및 생성 시각을 포함합니다.


2. Repository

- BookmarkRepository에서는 특정 사용자에 대해 이미 북마크한 대상 회원이 있는지 조회하는 메서드를 추가합니다.


3. Service

- BookmarkService에서는 현재 로그인한 사용자와 타깃 회원의 존재 여부를 확인하고, 중복 북마크 여부를 체크한 후 북마크 엔티티를 생성 및 저장합니다.


4. Controller

- BookmarkController는 JWT 인증이 완료된 Authentication 객체를 통해 사용자의 이메일을 추출하고, 경로 변수로 전달받은 대상 회원 ID를 기반으로 북마크 등록 요청을 처리합니다.
- 성공 시 201 CREATED 응답을, 오류 발생 시 상태 코드와 함께 단순 Map 형태의 메시지를 반환합니다.

