### PR TITLE
API-612-1_북마크 회원 조회

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,0 +1,48 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.service.BookmarkService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/users")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Autowired
+    public BookmarkController(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    // 북마크 회원 등록
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> createBookmark(@PathVariable("userId") Long targetUserId,
+                                            Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 식별자(이메일) 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkResponseDTO responseDTO = bookmarkService.createBookmark(targetUserId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // 에러에 따른 상태 코드를 반환합니다.
+            if ("대상 회원을 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 회원입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.taiso.bike_api.controller;
 
 import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserListResponseDTO;
 import com.taiso.bike_api.service.BookmarkService;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,21 @@ public class BookmarkController {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .body(Collections.singletonMap("message", errorMsg));
             }
+        }
+    }
+
+    // 북마크 회원 조회
+    @GetMapping
+    public ResponseEntity<?> getBookmarkedUsers(Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            BookmarkUserListResponseDTO responseDTO = bookmarkService.getBookmarkedUsers(reviewerEmail);
+            // 사양에 따르면 201 CREATED 응답 (비록 GET은 일반적으로 200 OK지만 스펙에 따름)
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
         }
     }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkResponseDTO {
+    private Long bookmarkId;
+    private Long userId;         // 북마크를 등록한 사용자
+    private Long targetUserId;   // 북마크 대상 사용자
+    private LocalDateTime createdAt;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserListResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkUserListResponseDTO {
+    private Long userId; // 현재 로그인한 사용자의 ID
+    private List<BookmarkUserResponseDTO> bookmarkedUsers;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserResponseDTO.java
@@ -1,0 +1,19 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkUserResponseDTO {
+    private Long userId;
+    private String userNickname;
+    private String userProfileImg;
+    private LocalDateTime createdAt; // 현재 사용자가 해당 회원을 북마크한 시각
+    private String gender;
+    private String level;
+    private Long totalBookmarks; // 해당 회원이 받은 전체 북마크 수
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -10,4 +10,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
     Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+    // 특정 대상 회원(타깃 유저)에 대해 북마크된 횟수를 반환
+    Long countByTargetTypeAndTargetId(BookmarkType targetType, Long targetId);
+
+    // 현재 사용자가 북마크한 대상들을 조회 (타깃이 USER인 경우)
+    java.util.List<BookmarkEntity> findByUserAndTargetType(UserEntity user, BookmarkType targetType);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.taiso.bike_api.repository;
 
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.taiso.bike_api.domain.BookmarkEntity;
-
 @Repository
-public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {}
+public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
+    Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -1,0 +1,56 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public BookmarkService(BookmarkRepository bookmarkRepository, UserRepository userRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 북마크 회원 등록
+    public BookmarkResponseDTO createBookmark(Long targetUserId, String reviewerEmail) {
+        // 현재 북마크를 등록하는 사용자 조회 (로그인한 사용자)
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("북마크 요청이 잘못됐습니다."));
+
+        // 타깃 유저(북마크 대상) 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 회원을 찾을 수 없습니다."));
+
+        // 이미 북마크한 회원인지 확인
+        Optional<BookmarkEntity> existingBookmark = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.USER, targetUserId);
+        if (existingBookmark.isPresent()) {
+            throw new IllegalArgumentException("이미 북마크한 회원입니다.");
+        }
+
+        // 북마크 엔티티 생성 및 저장
+        BookmarkEntity bookmark = BookmarkEntity.builder()
+                .user(user)
+                .targetType(BookmarkType.USER)
+                .targetId(targetUserId)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        return BookmarkResponseDTO.builder()
+                .bookmarkId(bookmark.getBookmarkId())
+                .userId(user.getUserId())
+                .targetUserId(targetUserId)
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -3,10 +3,16 @@ package com.taiso.bike_api.service;
 import com.taiso.bike_api.domain.BookmarkEntity;
 import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
 import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
 import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserListResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserResponseDTO;
 import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
 import com.taiso.bike_api.repository.UserRepository;
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,11 +21,15 @@ public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
+    private final UserDetailRepository userDetailRepository;
 
     @Autowired
-    public BookmarkService(BookmarkRepository bookmarkRepository, UserRepository userRepository) {
+    public BookmarkService(BookmarkRepository bookmarkRepository,
+                           UserRepository userRepository,
+                           UserDetailRepository userDetailRepository) {
         this.bookmarkRepository = bookmarkRepository;
         this.userRepository = userRepository;
+        this.userDetailRepository = userDetailRepository;
     }
 
     // 북마크 회원 등록
@@ -51,6 +61,49 @@ public class BookmarkService {
                 .userId(user.getUserId())
                 .targetUserId(targetUserId)
                 .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+
+    // 북마크 회원 조회
+    public BookmarkUserListResponseDTO getBookmarkedUsers(String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 현재 사용자가 북마크한 대상(타깃이 USER인 경우) 조회
+        List<BookmarkEntity> bookmarks = bookmarkRepository.findByUserAndTargetType(user, BookmarkType.USER);
+        if (bookmarks.isEmpty()) {
+            throw new IllegalArgumentException("북마크 해당 유저가 존재하지 않습니다.");
+        }
+
+        // 3. 각 북마크에 대해 대상 회원의 상세 정보 및 전체 북마크 수 조회 후 DTO 매핑
+        List<BookmarkUserResponseDTO> bookmarkedUsers = bookmarks.stream().map(bookmark -> {
+            Long targetUserId = bookmark.getTargetId();
+            // 대상 회원의 상세 정보 조회
+            UserDetailEntity detail = userDetailRepository.findById(targetUserId)
+                    .orElseThrow(() -> new IllegalArgumentException("대상 회원을 찾을 수 없습니다."));
+
+            // 전체 북마크 수 조회: 해당 대상이 USER 타입으로 북마크된 횟수
+            Long totalBookmarks = bookmarkRepository.countByTargetTypeAndTargetId(BookmarkType.USER, targetUserId);
+
+            // Gender, Level 등은 domain의 enum을 그대로 문자열로 변환하거나, 필요 시 매핑
+            String gender = detail.getGender().toString();  // 예: "남자" → 원하는 경우 "남성"으로 변환 가능
+            String level = detail.getLevel().toString();     // 예: "초보자", "입문자" 등
+
+            return BookmarkUserResponseDTO.builder()
+                    .userId(detail.getUserId())
+                    .userNickname(detail.getUserNickname())
+                    .userProfileImg(detail.getUserProfileImg())
+                    .createdAt(bookmark.getCreatedAt())
+                    .gender(gender)
+                    .level(level)
+                    .totalBookmarks(totalBookmarks)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return BookmarkUserListResponseDTO.builder()
+                .userId(user.getUserId())
+                .bookmarkedUsers(bookmarkedUsers)
                 .build();
     }
 }


### PR DESCRIPTION
API-612-1_북마크 회원 조회 요약


<추가 사항>

- BookmarkUserResponseDTO
- BookmarkUserListResponseDTO


<수정 사항>
- BookmarkController 로직 추가
- BookmarkService 로직 추가


<서비스 로직>

1. DTO

- BookmarkUserResponseDTO는 각 북마크 대상 회원의 정보(회원 ID, 닉네임, 프로필 이미지, 북마크 등록 시각, 성별, 레벨, 전체 북마크 수)를 담습니다.
- BookmarkUserListResponseDTO는 현재 사용자 ID와 북마크 대상 회원 목록을 포함합니다.


2. Repository

- BookmarkRepository는 현재 사용자가 북마크한 대상(타깃이 USER) 목록과, 특정 대상의 전체 북마크 수를 조회하는 메서드를 제공합니다.


3. Service

- BookmarkService에서는 현재 로그인한 사용자를 조회한 후, 해당 사용자가 북마크한 회원들을 조회하고, 각 대상의 상세 정보와 전체 북마크 수를 계산하여 DTO로 매핑합니다.


4. Controller

- BookmarkController는 SecurityFilterChain에서 JWT 인증이 완료되어 주입된 Authentication 객체를 활용하여 현재 사용자의 이메일을 추출한 후, 서비스 메서드를 호출하여 결과를 반환합니다.
- 오류 발생 시 단순 Map 형태로 메시지를 반환합니다.