### PR TITLE
API-641-1_북마크 루트 등록

### DIFF
--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
@@ -1,6 +1,7 @@
 package com.taiso.bike_api.controller;
 
 import com.taiso.bike_api.dto.BookmarkClubListResponseDTO;
+import com.taiso.bike_api.dto.BookmarkClubResponseDTO;
 import com.taiso.bike_api.service.BookmarkClubService;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,31 @@ public class BookmarkClubController {
     @Autowired
     public BookmarkClubController(BookmarkClubService bookmarkClubService) {
         this.bookmarkClubService = bookmarkClubService;
+    }
+
+
+    // 북마크 클럽 등록
+    @PostMapping("/{clubId}")
+    public ResponseEntity<?> createBookmarkClub(@PathVariable("clubId") Long clubId,
+                                                Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            BookmarkClubResponseDTO responseDTO = bookmarkClubService.createBookmarkClub(clubId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            if ("대상 클럽을 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 클럽입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
     }
 
     // 북마크 클럽 조회

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
@@ -61,4 +61,27 @@ public class BookmarkClubController {
                     .body(Collections.singletonMap("message", e.getMessage()));
         }
     }
+
+    // 북마크 클럽 취소
+    @DeleteMapping("/{clubId}")
+    public ResponseEntity<?> cancelBookmarkClub(@PathVariable("clubId") Long clubId,
+                                                Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일(식별자) 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            bookmarkClubService.cancelBookmarkClub(clubId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                    .body(Collections.singletonMap("message", "북마크를 삭제했습니다."));
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // "북마크한 게시글이 아닙니다."는 404 Not Found로 반환
+            if ("북마크한 게시글이 아닙니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkClubController.java
@@ -1,0 +1,38 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkClubListResponseDTO;
+import com.taiso.bike_api.service.BookmarkClubService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/clubs")
+public class BookmarkClubController {
+
+    private final BookmarkClubService bookmarkClubService;
+
+    @Autowired
+    public BookmarkClubController(BookmarkClubService bookmarkClubService) {
+        this.bookmarkClubService = bookmarkClubService;
+    }
+
+    // 북마크 클럽 조회
+    @GetMapping
+    public ResponseEntity<?> getBookmarkedClubs(Authentication authentication) {
+        // 인증 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkClubListResponseDTO responseDTO = bookmarkClubService.getBookmarkedClubs(reviewerEmail);
+            // 스펙에 따르면 201 Created 응답
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,0 +1,48 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.service.BookmarkService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/users")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Autowired
+    public BookmarkController(BookmarkService bookmarkService) {
+        this.bookmarkService = bookmarkService;
+    }
+
+    // 북마크 회원 등록
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> createBookmark(@PathVariable("userId") Long targetUserId,
+                                            Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 식별자(이메일) 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkResponseDTO responseDTO = bookmarkService.createBookmark(targetUserId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // 에러에 따른 상태 코드를 반환합니다.
+            if ("대상 회원을 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 회원입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.taiso.bike_api.controller;
 
 import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserListResponseDTO;
 import com.taiso.bike_api.service.BookmarkService;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,21 @@ public class BookmarkController {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .body(Collections.singletonMap("message", errorMsg));
             }
+        }
+    }
+
+    // 북마크 회원 조회
+    @GetMapping
+    public ResponseEntity<?> getBookmarkedUsers(Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            BookmarkUserListResponseDTO responseDTO = bookmarkService.getBookmarkedUsers(reviewerEmail);
+            // 사양에 따르면 201 CREATED 응답 (비록 GET은 일반적으로 200 OK지만 스펙에 따름)
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
         }
     }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkController.java
@@ -1,10 +1,11 @@
 package com.taiso.bike_api.controller;
 
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.taiso.bike_api.dto.BookmarkResponseDTO;
 import com.taiso.bike_api.dto.BookmarkUserListResponseDTO;
 import com.taiso.bike_api.service.BookmarkService;
-import java.util.Collections;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -59,6 +60,31 @@ public class BookmarkController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+
+    // API-614-1_북마크 회원 취소
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<?> cancelBookmark(@PathVariable("userId") Long targetUserId,
+                                            Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일(식별자) 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            bookmarkService.cancelBookmark(targetUserId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                    .body(Collections.singletonMap("message", "북마크를 삭제했습니다."));
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            if ("북마크 해당 유저가 존재하지 않습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("북마크한 회원이 아닙니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
         }
     }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkLightningController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkLightningController.java
@@ -1,0 +1,70 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkLightningListResponseDTO;
+import com.taiso.bike_api.dto.BookmarkLightningResponseDTO;
+import com.taiso.bike_api.service.BookmarkLightningService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/lightnings")
+public class BookmarkLightningController {
+
+    private final BookmarkLightningService bookmarkLightningService;
+
+    @Autowired
+    public BookmarkLightningController(BookmarkLightningService bookmarkLightningService) {
+        this.bookmarkLightningService = bookmarkLightningService;
+    }
+
+    // 북마크 번개 등록
+    @PostMapping("/{lightningId}")
+    public ResponseEntity<?> createBookmark(
+            @PathVariable("lightningId") Long lightningId,
+            Authentication authentication) {
+
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkLightningResponseDTO responseDTO = bookmarkLightningService.createBookmark(lightningId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            if ("대상 번개를 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 번개입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
+
+    // 북마크 번개 조회
+    @GetMapping
+    public ResponseEntity<?> getBookmarkLightnings(Authentication authentication) {
+        // Authentication 객체가 없으면 UNAUTHORIZED 응답
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Collections.singletonMap("message", "토큰이 존재하지 않습니다."));
+        }
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkLightningListResponseDTO responseDTO = bookmarkLightningService.getBookmarkLightnings(reviewerEmail);
+            // 사양에 따르면 201 CREATED 응답 (GET일 경우 일반적으로 200 OK이나, 스펙에 따름)
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Collections.singletonMap("message", e.getMessage()));
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkLightningController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkLightningController.java
@@ -67,4 +67,23 @@ public class BookmarkLightningController {
                     .body(Collections.singletonMap("message", e.getMessage()));
         }
     }
+
+    // 북마크 번개 취소
+    @DeleteMapping("/{lightningId}")
+    public ResponseEntity<?> cancelBookmarkLightning(@PathVariable("lightningId") Long lightningId,
+                                                     Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+        try {
+            bookmarkLightningService.cancelBookmarkLightning(lightningId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                    .body(Collections.singletonMap("message", "북마크를 삭제했습니다."));
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            // "토큰이 존재하지 않습니다."와 "만료되거나 올바르지 않은 토큰 입니다."는 SecurityFilterChain에서 처리되므로 여기선 주로 404로 처리
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Collections.singletonMap("message", errorMsg));
+        }
+    }
+
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkRouteController.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/controller/BookmarkRouteController.java
@@ -1,0 +1,47 @@
+package com.taiso.bike_api.controller;
+
+import com.taiso.bike_api.dto.BookmarkRouteResponseDTO;
+import com.taiso.bike_api.service.BookmarkRouteService;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/bookmarks/routes")
+public class BookmarkRouteController {
+
+    private final BookmarkRouteService bookmarkRouteService;
+
+    @Autowired
+    public BookmarkRouteController(BookmarkRouteService bookmarkRouteService) {
+        this.bookmarkRouteService = bookmarkRouteService;
+    }
+
+    // 북마크 루트 등록
+    @PostMapping("/{routeId}")
+    public ResponseEntity<?> createBookmark(@PathVariable("routeId") Long routeId,
+                                            Authentication authentication) {
+        // Authentication 객체에서 현재 사용자의 이메일 추출
+        String reviewerEmail = authentication.getName();
+
+        try {
+            BookmarkRouteResponseDTO responseDTO = bookmarkRouteService.createBookmark(routeId, reviewerEmail);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            String errorMsg = e.getMessage();
+            if ("대상 루트를 찾을 수 없습니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else if ("이미 북마크한 루트입니다.".equals(errorMsg)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Collections.singletonMap("message", errorMsg));
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Collections.singletonMap("message", errorMsg));
+            }
+        }
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubDTO.java
@@ -1,0 +1,18 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkClubDTO {
+    private Long bookmarkId;
+    private LocalDateTime bookmarkDate;  // 북마크 등록 일시 (createdAt)
+    private Long clubId;
+    private String clubName;
+    private String clubShortDescription;
+    private Integer maxUser;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubListResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkClubListResponseDTO {
+    private Long userId;  // 현재 사용자의 ID
+    private List<BookmarkClubDTO> bookmarkClub;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkClubResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkClubResponseDTO {
+    private Long bookmarkId;
+    private Long userId;      // 북마크를 등록한 사용자 ID
+    private Long clubId;      // 북마크 대상 클럽 ID
+    private LocalDateTime createdAt; // 북마크 등록 시각
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningDTO.java
@@ -1,0 +1,25 @@
+package com.taiso.bike_api.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkLightningDTO {
+    private Long bookmarkId;
+    private LocalDateTime bookmarkDate; // 북마크 등록 일시
+    private Long lightningId;
+    private String title;
+    private LocalDateTime eventDate;
+    private Integer duration;
+    private String status;       // 예: 모집, 마감, 종료, 취소
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private Integer capacity;
+    private String gender;
+    private String level;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningListResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkLightningListResponseDTO {
+    private Long userId;  // 북마크를 등록한 사용자 ID (현재 사용자)
+    private List<BookmarkLightningDTO> bookmarkedLightnings;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkLightningResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkLightningResponseDTO {
+    private Long bookmarkId;
+    private Long userId;         // 북마크를 등록한 사용자 ID
+    private Long lightningId;    // 북마크 대상 번개 ID
+    private LocalDateTime createdAt;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkResponseDTO {
+    private Long bookmarkId;
+    private Long userId;         // 북마크를 등록한 사용자
+    private Long targetUserId;   // 북마크 대상 사용자
+    private LocalDateTime createdAt;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkRouteResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkRouteResponseDTO.java
@@ -1,0 +1,16 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkRouteResponseDTO {
+    private Long bookmarkId;
+    private Long userId;       // 북마크를 등록한 사용자 ID
+    private Long routeId;      // 북마크 대상 루트 ID
+    private LocalDateTime createdAt;  // 북마크 등록 시각
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserListResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.taiso.bike_api.dto;
+
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkUserListResponseDTO {
+    private Long userId; // 현재 로그인한 사용자의 ID
+    private List<BookmarkUserResponseDTO> bookmarkedUsers;
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserResponseDTO.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/dto/BookmarkUserResponseDTO.java
@@ -1,0 +1,19 @@
+package com.taiso.bike_api.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkUserResponseDTO {
+    private Long userId;
+    private String userNickname;
+    private String userProfileImg;
+    private LocalDateTime createdAt; // 현재 사용자가 해당 회원을 북마크한 시각
+    private String gender;
+    private String level;
+    private Long totalBookmarks; // 해당 회원이 받은 전체 북마크 수
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -10,4 +10,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
     Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+    // 특정 대상 회원(타깃 유저)에 대해 북마크된 횟수를 반환
+    Long countByTargetTypeAndTargetId(BookmarkType targetType, Long targetId);
+
+    // 현재 사용자가 북마크한 대상들을 조회 (타깃이 USER인 경우)
+    java.util.List<BookmarkEntity> findByUserAndTargetType(UserEntity user, BookmarkType targetType);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.taiso.bike_api.repository;
 
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.taiso.bike_api.domain.BookmarkEntity;
-
 @Repository
-public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {}
+public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
+    Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
     Optional<BookmarkEntity> findByUserAndTargetTypeAndTargetId(UserEntity user, BookmarkType targetType, Long targetId);
+
     // 특정 대상 회원(타깃 유저)에 대해 북마크된 횟수를 반환
     Long countByTargetTypeAndTargetId(BookmarkType targetType, Long targetId);
 

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/BookmarkRepository.java
@@ -3,6 +3,8 @@ package com.taiso.bike_api.repository;
 import com.taiso.bike_api.domain.BookmarkEntity;
 import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
 import com.taiso.bike_api.domain.UserEntity;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,5 +16,5 @@ public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> 
     Long countByTargetTypeAndTargetId(BookmarkType targetType, Long targetId);
 
     // 현재 사용자가 북마크한 대상들을 조회 (타깃이 USER인 경우)
-    java.util.List<BookmarkEntity> findByUserAndTargetType(UserEntity user, BookmarkType targetType);
+    List<BookmarkEntity> findByUserAndTargetType(UserEntity user, BookmarkType targetType);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/LightningRepository.java
@@ -1,10 +1,11 @@
 package com.taiso.bike_api.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-
 import com.taiso.bike_api.domain.LightningEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface LightningRepository extends JpaRepository<LightningEntity, Long>, JpaSpecificationExecutor<LightningEntity>{
-    
+@Repository
+public interface LightningRepository extends JpaRepository<LightningEntity, Long> {
+    Optional<LightningEntity> findById(Long lightningId);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/repository/RouteRepository.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/repository/RouteRepository.java
@@ -1,10 +1,11 @@
 package com.taiso.bike_api.repository;
 
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-
 import com.taiso.bike_api.domain.RouteEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface RouteRepository extends JpaRepository<RouteEntity, Long>, JpaSpecificationExecutor<RouteEntity> {
+@Repository
+public interface RouteRepository extends JpaRepository<RouteEntity, Long> {
+    Optional<RouteEntity> findById(Long routeId);
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkClubService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkClubService.java
@@ -1,0 +1,61 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.ClubEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkClubDTO;
+import com.taiso.bike_api.dto.BookmarkClubListResponseDTO;
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.ClubRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkClubService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+    private final ClubRepository clubRepository;
+
+    @Autowired
+    public BookmarkClubService(BookmarkRepository bookmarkRepository,
+                               UserRepository userRepository,
+                               ClubRepository clubRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.userRepository = userRepository;
+        this.clubRepository = clubRepository;
+    }
+
+    // 북마크 클럽 조회
+    public BookmarkClubListResponseDTO getBookmarkedClubs(String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 현재 사용자가 북마크한 클럽 북마크 조회 (타깃 타입이 CLUB)
+        List<BookmarkEntity> bookmarks = bookmarkRepository.findByUserAndTargetType(user, BookmarkType.CLUB);
+
+        // 3. 각 북마크에 대해 대상 클럽 정보를 조회하여 DTO 매핑
+        List<BookmarkClubDTO> bookmarkClubList = bookmarks.stream().map(bookmark -> {
+            ClubEntity club = clubRepository.findById(bookmark.getTargetId())
+                    .orElseThrow(() -> new IllegalArgumentException("대상 클럽을 찾을 수 없습니다."));
+            return BookmarkClubDTO.builder()
+                    .bookmarkId(bookmark.getBookmarkId())
+                    .bookmarkDate(bookmark.getCreatedAt())
+                    .clubId(club.getClubId())
+                    .clubName(club.getClubName())
+                    .clubShortDescription(club.getClubShortDescription())
+                    .maxUser(club.getMaxUser())
+                    .build();
+        }).collect(Collectors.toList());
+
+        return BookmarkClubListResponseDTO.builder()
+                .userId(user.getUserId())
+                .bookmarkClub(bookmarkClubList)
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkClubService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkClubService.java
@@ -95,4 +95,21 @@ public class BookmarkClubService {
                 .bookmarkClub(bookmarkClubList)
                 .build();
     }
+
+    // 북마크 클럽 취소
+    public void cancelBookmarkClub(Long clubId, String reviewerEmail) {
+        // 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 북마크 대상이 CLUB인 북마크가 존재하는지 확인
+        Optional<BookmarkEntity> bookmarkOpt = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.CLUB, clubId);
+        if (!bookmarkOpt.isPresent()) {
+            throw new IllegalArgumentException("북마크한 게시글이 아닙니다.");
+        }
+
+        // 북마크 삭제
+        bookmarkRepository.delete(bookmarkOpt.get());
+    }
+
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkLightningService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkLightningService.java
@@ -1,0 +1,107 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.LightningEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkLightningDTO;
+import com.taiso.bike_api.dto.BookmarkLightningResponseDTO;
+import com.taiso.bike_api.dto.BookmarkLightningListResponseDTO;
+
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.LightningRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkLightningService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final LightningRepository lightningRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public BookmarkLightningService(BookmarkRepository bookmarkRepository,
+                                    LightningRepository lightningRepository,
+                                    UserRepository userRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.lightningRepository = lightningRepository;
+        this.userRepository = userRepository;
+    }
+
+    
+    // 북마크 번개 등록
+    public BookmarkLightningResponseDTO createBookmark(Long lightningId, String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 번개 이벤트 존재 여부 확인
+        LightningEntity lightning = lightningRepository.findById(lightningId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 번개를 찾을 수 없습니다."));
+
+        // 3. 이미 북마크한 번개인지 확인
+        Optional<BookmarkEntity> existing = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.LIGHTNING, lightningId);
+        if (existing.isPresent()) {
+            throw new IllegalArgumentException("이미 북마크한 번개입니다.");
+        }
+
+        // 4. 북마크 엔티티 생성 및 저장
+        BookmarkEntity bookmark = BookmarkEntity.builder()
+                .user(user)
+                .targetType(BookmarkType.LIGHTNING)
+                .targetId(lightningId)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        // 5. 응답 DTO 구성
+        return BookmarkLightningResponseDTO.builder()
+                .bookmarkId(bookmark.getBookmarkId())
+                .userId(user.getUserId())
+                .lightningId(lightning.getLightningId())
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+    
+    // 북마크 번개 조회
+    public BookmarkLightningListResponseDTO getBookmarkLightnings(String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 현재 사용자가 북마크한 번개 이벤트 조회 (타깃 타입이 LIGHTNING)
+        List<BookmarkEntity> bookmarks = bookmarkRepository.findByUserAndTargetType(user, BookmarkType.LIGHTNING);
+
+        // 3. 각 북마크에 대해 대상 번개 이벤트를 조회하여 DTO로 매핑
+        List<BookmarkLightningDTO> dtoList = bookmarks.stream().map(bookmark -> {
+            LightningEntity lightning = lightningRepository.findById(bookmark.getTargetId())
+                    .orElseThrow(() -> new IllegalArgumentException("대상 번개를 찾을 수 없습니다."));
+
+            return BookmarkLightningDTO.builder()
+                    .bookmarkId(bookmark.getBookmarkId())
+                    .bookmarkDate(bookmark.getCreatedAt())
+                    .lightningId(lightning.getLightningId())
+                    .title(lightning.getTitle())
+                    .eventDate(lightning.getEventDate())
+                    .duration(lightning.getDuration())
+                    .status(lightning.getStatus().toString())
+                    .latitude(lightning.getLatitude())
+                    .longitude(lightning.getLongitude())
+                    .capacity(lightning.getCapacity())
+                    .gender(lightning.getGender().toString())
+                    .level(lightning.getLevel().toString())
+                    .build();
+        }).collect(Collectors.toList());
+
+        return BookmarkLightningListResponseDTO.builder()
+                .userId(user.getUserId())
+                .bookmarkedLightnings(dtoList)
+                .build();
+    }
+
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkLightningService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkLightningService.java
@@ -7,10 +7,10 @@ import com.taiso.bike_api.domain.UserEntity;
 import com.taiso.bike_api.dto.BookmarkLightningDTO;
 import com.taiso.bike_api.dto.BookmarkLightningResponseDTO;
 import com.taiso.bike_api.dto.BookmarkLightningListResponseDTO;
-
 import com.taiso.bike_api.repository.BookmarkRepository;
 import com.taiso.bike_api.repository.LightningRepository;
 import com.taiso.bike_api.repository.UserRepository;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -102,6 +102,22 @@ public class BookmarkLightningService {
                 .userId(user.getUserId())
                 .bookmarkedLightnings(dtoList)
                 .build();
+    }
+
+    // 북마크 번개 취소
+    public void cancelBookmarkLightning(Long lightningId, String reviewerEmail) {
+        // 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 북마크한 번개가 존재하는지 확인 (타깃 타입이 LIGHTNING)
+        Optional<BookmarkEntity> bookmarkOpt = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.LIGHTNING, lightningId);
+        if (!bookmarkOpt.isPresent()) {
+            throw new IllegalArgumentException("북마크한 게시글이 아닙니다.");
+        }
+
+        // 북마크 삭제
+        bookmarkRepository.delete(bookmarkOpt.get());
     }
 
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkRouteService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkRouteService.java
@@ -1,0 +1,63 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.RouteEntity;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkRouteResponseDTO;
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.RouteRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkRouteService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+    private final RouteRepository routeRepository;
+
+    @Autowired
+    public BookmarkRouteService(BookmarkRepository bookmarkRepository,
+                                UserRepository userRepository,
+                                RouteRepository routeRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.userRepository = userRepository;
+        this.routeRepository = routeRepository;
+    }
+
+    // 북마크 루트 등록
+    public BookmarkRouteResponseDTO createBookmark(Long routeId, String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 대상 루트 존재 여부 확인
+        RouteEntity route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 루트를 찾을 수 없습니다."));
+
+        // 3. 이미 북마크한 루트인지 확인
+        Optional<BookmarkEntity> existing = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.ROUTE, routeId);
+        if (existing.isPresent()) {
+            throw new IllegalArgumentException("이미 북마크한 루트입니다.");
+        }
+
+        // 4. 북마크 엔티티 생성 및 저장
+        BookmarkEntity bookmark = BookmarkEntity.builder()
+                .user(user)
+                .targetType(BookmarkType.ROUTE)
+                .targetId(routeId)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        // 5. 응답 DTO 구성
+        return BookmarkRouteResponseDTO.builder()
+                .bookmarkId(bookmark.getBookmarkId())
+                .userId(user.getUserId())
+                .routeId(route.getRouteId())
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -1,0 +1,56 @@
+package com.taiso.bike_api.service;
+
+import com.taiso.bike_api.domain.BookmarkEntity;
+import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
+import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.UserRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public BookmarkService(BookmarkRepository bookmarkRepository, UserRepository userRepository) {
+        this.bookmarkRepository = bookmarkRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 북마크 회원 등록
+    public BookmarkResponseDTO createBookmark(Long targetUserId, String reviewerEmail) {
+        // 현재 북마크를 등록하는 사용자 조회 (로그인한 사용자)
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("북마크 요청이 잘못됐습니다."));
+
+        // 타깃 유저(북마크 대상) 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 회원을 찾을 수 없습니다."));
+
+        // 이미 북마크한 회원인지 확인
+        Optional<BookmarkEntity> existingBookmark = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.USER, targetUserId);
+        if (existingBookmark.isPresent()) {
+            throw new IllegalArgumentException("이미 북마크한 회원입니다.");
+        }
+
+        // 북마크 엔티티 생성 및 저장
+        BookmarkEntity bookmark = BookmarkEntity.builder()
+                .user(user)
+                .targetType(BookmarkType.USER)
+                .targetId(targetUserId)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        return BookmarkResponseDTO.builder()
+                .bookmarkId(bookmark.getBookmarkId())
+                .userId(user.getUserId())
+                .targetUserId(targetUserId)
+                .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+}

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -3,10 +3,16 @@ package com.taiso.bike_api.service;
 import com.taiso.bike_api.domain.BookmarkEntity;
 import com.taiso.bike_api.domain.BookmarkEntity.BookmarkType;
 import com.taiso.bike_api.domain.UserEntity;
+import com.taiso.bike_api.domain.UserDetailEntity;
 import com.taiso.bike_api.dto.BookmarkResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserListResponseDTO;
+import com.taiso.bike_api.dto.BookmarkUserResponseDTO;
 import com.taiso.bike_api.repository.BookmarkRepository;
+import com.taiso.bike_api.repository.UserDetailRepository;
 import com.taiso.bike_api.repository.UserRepository;
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,11 +21,15 @@ public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
+    private final UserDetailRepository userDetailRepository;
 
     @Autowired
-    public BookmarkService(BookmarkRepository bookmarkRepository, UserRepository userRepository) {
+    public BookmarkService(BookmarkRepository bookmarkRepository,
+                           UserRepository userRepository,
+                           UserDetailRepository userDetailRepository) {
         this.bookmarkRepository = bookmarkRepository;
         this.userRepository = userRepository;
+        this.userDetailRepository = userDetailRepository;
     }
 
     // 북마크 회원 등록
@@ -51,6 +61,49 @@ public class BookmarkService {
                 .userId(user.getUserId())
                 .targetUserId(targetUserId)
                 .createdAt(bookmark.getCreatedAt())
+                .build();
+    }
+
+    // 북마크 회원 조회
+    public BookmarkUserListResponseDTO getBookmarkedUsers(String reviewerEmail) {
+        // 1. 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 2. 현재 사용자가 북마크한 대상(타깃이 USER인 경우) 조회
+        List<BookmarkEntity> bookmarks = bookmarkRepository.findByUserAndTargetType(user, BookmarkType.USER);
+        if (bookmarks.isEmpty()) {
+            throw new IllegalArgumentException("북마크 해당 유저가 존재하지 않습니다.");
+        }
+
+        // 3. 각 북마크에 대해 대상 회원의 상세 정보 및 전체 북마크 수 조회 후 DTO 매핑
+        List<BookmarkUserResponseDTO> bookmarkedUsers = bookmarks.stream().map(bookmark -> {
+            Long targetUserId = bookmark.getTargetId();
+            // 대상 회원의 상세 정보 조회
+            UserDetailEntity detail = userDetailRepository.findById(targetUserId)
+                    .orElseThrow(() -> new IllegalArgumentException("대상 회원을 찾을 수 없습니다."));
+
+            // 전체 북마크 수 조회: 해당 대상이 USER 타입으로 북마크된 횟수
+            Long totalBookmarks = bookmarkRepository.countByTargetTypeAndTargetId(BookmarkType.USER, targetUserId);
+
+            // Gender, Level 등은 domain의 enum을 그대로 문자열로 변환하거나, 필요 시 매핑
+            String gender = detail.getGender().toString();  // 예: "남자" → 원하는 경우 "남성"으로 변환 가능
+            String level = detail.getLevel().toString();     // 예: "초보자", "입문자" 등
+
+            return BookmarkUserResponseDTO.builder()
+                    .userId(detail.getUserId())
+                    .userNickname(detail.getUserNickname())
+                    .userProfileImg(detail.getUserProfileImg())
+                    .createdAt(bookmark.getCreatedAt())
+                    .gender(gender)
+                    .level(level)
+                    .totalBookmarks(totalBookmarks)
+                    .build();
+        }).collect(Collectors.toList());
+
+        return BookmarkUserListResponseDTO.builder()
+                .userId(user.getUserId())
+                .bookmarkedUsers(bookmarkedUsers)
                 .build();
     }
 }

--- a/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
+++ b/bike-api/src/main/java/com/taiso/bike_api/service/BookmarkService.java
@@ -106,4 +106,25 @@ public class BookmarkService {
                 .bookmarkedUsers(bookmarkedUsers)
                 .build();
     }
+
+    // 북마크 회원 취소
+    public void cancelBookmark(Long targetUserId, String reviewerEmail) {
+        // 현재 북마크 등록자(사용자) 조회
+        UserEntity user = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
+
+        // 타깃 회원 존재 여부 확인
+        UserEntity targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("북마크 해당 유저가 존재하지 않습니다."));
+
+        // 해당 사용자가 타깃 회원을 북마크한 기록 조회
+        Optional<BookmarkEntity> bookmarkOpt = bookmarkRepository.findByUserAndTargetTypeAndTargetId(user, BookmarkType.USER, targetUserId);
+        if (!bookmarkOpt.isPresent()) {
+            throw new IllegalArgumentException("북마크한 회원이 아닙니다.");
+        }
+
+        // 북마크 삭제
+        bookmarkRepository.delete(bookmarkOpt.get());
+    }
+
 }


### PR DESCRIPTION
API-641-1_북마크 루트 등록 요약



<추가 사항>

- BookmarkRouteResponseDTO
- BookmarkRouteService
- BookmarkRouteController

<수정 사항>


<서비스 로직>

DTO:
BookmarkRouteResponseDTO는 북마크 등록 후 응답에 필요한 정보(북마크 ID, 등록한 사용자 ID, 대상 루트 ID, 북마크 등록 시각)를 포함합니다.

Repository:
BookmarkRepository를 활용하여 현재 사용자가 대상 루트(BookmarkType.ROUTE)에 대해 북마크를 이미 등록했는지 조회합니다.
RouteRepository를 사용해 대상 루트의 존재 여부를 확인합니다.

Service:
BookmarkRouteService는 현재 로그인한 사용자(이메일 기반)를 조회하고, 대상 루트의 존재 여부 및 중복 북마크 여부를 체크한 후 북마크 엔티티를 생성, 저장하고 응답 DTO를 반환합니다.

Controller:
BookmarkRouteController는 Authentication 객체를 통해 JWT 인증이 완료된 현재 사용자의 이메일을 추출하고, 서비스 메서드를 호출하여 성공 시 201 CREATED 응답과 함께 응답 DTO를 반환하며, 오류 발생 시 단순 Map 형태의 메시지를 적절한 HTTP 상태 코드와 함께 반환합니다.

